### PR TITLE
Few small fixes

### DIFF
--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -315,7 +315,7 @@ SUB CombatAbilities
     |/echo car ${Me.CombatAbilityReady[${abilityName}]} ${Me.CombatAbility[${abilityName}]} ${abilityName} ${Me.CombatAbilityReady[${abilityName}]} ${Me.CombatAbilityReady[Backstab]}
       /if (${Me.CombatAbilityReady[${Abilities2D[${i},${iCastName}]}]}) {
         |/echo ${Abilities2D[${i},${iCastName}]} myend ${Me.PctEndurance} >= minend ${Abilities2D[${i},${iMinEnd}]} and endcost ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance}
-        /if (${Me.PctEndurance} >= ${Abilities2D[${i},${iMinEnd}]} && ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance}) {
+        /if (${Me.PctEndurance} >= ${Abilities2D[${i},${iMinEnd}]} && ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance} && ${Abilities2D[${i},${iIfs}]}) {
           |/echo ready ${abilityName} ${Me.CombatAbilityReady[${abilityName}]}
           /disc ${Abilities2D[${i},${iCastName}]}
           /delay 3 !${Me.CombatAbilityReady[${Abilities2D[${i},${iCastName}]}]}

--- a/Macros/e3 Includes/e3_BuffCheck.inc
+++ b/Macros/e3 Includes/e3_BuffCheck.inc
@@ -226,6 +226,7 @@ SUB checkAuras
       /if (${c_Ready}) {
         /if (${check_Mana["auraSpells2D",1]}) {
           /call e3_Cast ${Me.ID} "auraSpells2D" "1"
+          /delay 7s !${Me.Casting.ID}
         }
       }
     }


### PR DESCRIPTION
Couple fixes that tested well for me.

I ran into the aura recast loop bug in which my warrior at 55 would cast aura but never complete it, because it would interrupt and try to cast again. It just needed a delay to complete the aura cast, then all was fine.

While trying to automate "Second Wind" on my monk it would simply not work. Digging into the code I found that custom ifs are not enabled for disciplines. I don't know why that is. Anyways, this change has tested well for me so far.

Example usage:

```
[Melee Abilities]
Ability=Second Wind/Ifs|NeedEndurance
...
[Ifs]
NeedEndurance=${Me.PctEndurance} < 40
```

Discord: Corporate
In-game: Tron