### PR TITLE
Manastone toggle

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2235,7 +2235,7 @@ SUB EVENT_LinkLoot(line, chatSender, bag, channel)
   Install Instructions:                                   
   1) Add this SUB and check_StoneOn to the bottom of e3 Includes/e3_Basics.inc 
   2) Add /doevents manastoneToggle to Sub basics_Background_Events
-  3) Put check_StoneOn in Advanced Settings.ini for the characters with a manastone (be sure to increment the number)
+  3) Add /call check_StoneOn to Sub basics_Background_Events
   Add Alias (optional):
   /alias /stoneToggle /bc stone toggle
 **|

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1587,6 +1587,7 @@ Sub basics_Background_Events
   /doevents gimme
   /doevents LinkLoot
   /doevents collect
+  /doevents manastoneToggle
 |		/varset event_counter 1
 |	} else {
 |		/varcalc event_counter ${event_counter}+1
@@ -2216,4 +2217,67 @@ SUB EVENT_LinkLoot(line, chatSender, bag, channel)
 			/gu ----
 		}
 	}
+/RETURN
+
+|**
+  Author: Sirhopsalot
+
+  Toggles manastone on/off
+  Will automatically toggle back off when mana is 100%
+  Can be toggled off while manastone is active
+
+  Usage:
+  Enable/disable manastone for one character: /t characterName stone toggle
+  Enable/disable manastone for all characters: /bc stone toggle
+  Enable/disable manastone for the group: /g stone toggle
+  
+  Install Instructions:                                   
+  1) Add this SUB and check_StoneOn to the bottom of e3 Includes/e3_Basics.inc 
+  2) Add /doevents manastoneToggle to Sub basics_Background_Events
+  3) Put check_StoneOn in Advanced Settings.ini for the characters with a manastone (be sure to increment the number)
+  Add Alias (optional):
+  /alias /stoneToggle /bc stone toggle
+**|
+#event manastoneToggle "#1# tells you, 'stone toggle'"
+#event manastoneToggle "<#1#> stone toggle"
+#event manastoneToggle "#1# tells the group, 'stone toggle'"
+SUB event_manastoneToggle(line, ChatSender)
+  /if (!${Defined[stoneOn]}) {
+    /declare stoneOn bool outer TRUE
+  } else /if (${stoneOn}) {
+    /varset stoneOn FALSE
+  } else {
+    /varset stoneOn TRUE
+  }
+
+  /if (!${Bool[${FindItem[=Manastone]}]} && ${stoneOn}) {
+    /varset stoneOn FALSE
+  } else /if (${stoneOn}) {
+    /docommand ${ChatToggle} Manastone on
+  } else {
+    /docommand ${ChatToggle} Manastone off
+  }
+/RETURN
+
+|**
+  Put this in Advanced Settings.ini for the characters with a manastone
+**|
+SUB check_StoneOn
+  /if (!${Defined[stoneOn]}) {
+    /declare stoneOn bool outer FALSE
+  }
+
+  /if (${stoneOn} && ${Me.PctMana} < 100 && ${Me.PctHPs} > 70) {
+    /declare i int local
+    | hit the stone 10 times
+    /for i 1 to 10
+      /casting "Manastone"
+      /delay 1
+    /next i
+  }
+
+  /if (${stoneOn} && ${Me.PctMana} >= 100) {
+    /varset stoneOn FALSE
+    /docommand ${ChatToggle} Manastone off, mana 100%
+  }
 /RETURN

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2261,7 +2261,8 @@ SUB event_manastoneToggle(line, ChatSender)
 /RETURN
 
 |**
-  Put this in Advanced Settings.ini for the characters with a manastone
+  Checks if the stoneOn variable is TRUE and clicks the manastone 10 times
+  Sets stoneOn to false when the toon's mana reaches 100%
 **|
 SUB check_StoneOn
   /if (!${Defined[stoneOn]}) {

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1588,6 +1588,7 @@ Sub basics_Background_Events
   /doevents LinkLoot
   /doevents collect
   /doevents manastoneToggle
+  /call check_StoneOn
 |		/varset event_counter 1
 |	} else {
 |		/varcalc event_counter ${event_counter}+1

--- a/Macros/e3 Macro Inis/Advanced Settings.ini
+++ b/Macros/e3 Macro Inis/Advanced Settings.ini
@@ -136,6 +136,7 @@ PAL Function#4=check_Heals
 PAL Function#5=check_Cures
 PAL Function#6=check_Buffs
 PAL Function#7=check_Nukes
+PAL Function#8=check_StoneOn
 [RNG Functions]
 RNG Function#1=check_Burns
 RNG Function#2=check_Heals

--- a/Macros/e3 Macro Inis/Advanced Settings.ini
+++ b/Macros/e3 Macro Inis/Advanced Settings.ini
@@ -136,7 +136,6 @@ PAL Function#4=check_Heals
 PAL Function#5=check_Cures
 PAL Function#6=check_Buffs
 PAL Function#7=check_Nukes
-PAL Function#8=check_StoneOn
 [RNG Functions]
 RNG Function#1=check_Burns
 RNG Function#2=check_Heals


### PR DESCRIPTION
Toggles manastone usage on/off. When on, the toon will click the stone 10 times then check if the toggle is still on. It will automatically toggle back off when mana is 100%.