### PR TITLE
Queue Cast and Clear XTargets

### DIFF
--- a/Macros/e3 Includes/e3_ClearXTargets.inc
+++ b/Macros/e3 Includes/e3_ClearXTargets.inc
@@ -1,0 +1,125 @@
+|--------------------------------------------------------------------------------|
+| Clear XTargets
+|
+| Author: Sirhopsalot
+| Contributor: Forsy
+|
+| Starts assist on each of the targets in your XTarget list until they're all Cleared using the criteria below
+| This will cause the toon to stick to the current target, face the mob if looking the wrong way, and re-stick if the mob is too far away
+| Calling Clear XTargets again while still clearing toggles it back off
+|
+| Selects the next target from the XTarget list using the following criteria:
+| 1) Lowest aggro on the list
+| 2) Highest health on the list
+| 2a) Prefers non-Warrior targets with the same aggro over Warrior targets (kill healers/casters/rogues/etc first)
+
+| Usage to clear everything:
+|    /bc Clear XTargets
+| Usage to select just the next target using the criteria (useful for switching to adds on boss fights)
+|    /bc Next Target
+|
+| Installation:
+| 1) Put e3_ClearXTargets.inc in the e3 Includes folder
+| 2) In e3_Setup.inc, add: #include e3 Includes\e3_ClearXTargets.inc
+| 3) In Advanced Settings.ini, add: Include#21=clearXTargets under [Included Setups]
+|--------------------------------------------------------------------------------|
+
+|--------------------------------------------------------------------------------|
+| Declare variables used in the macros
+|--------------------------------------------------------------------------------|
+Sub clearXTargets_Setup
+	/declare clearXTargetsOn bool outer FALSE
+/RETURN
+
+|--------------------------------------------------------------------------------|
+| Call background events and other subs required for checking the macros
+|--------------------------------------------------------------------------------|
+Sub clearXTargets_Background_Events
+	/doevents nextTarget
+	/doevents clearXTargets
+	/call check_clearXTargets
+/return
+
+| Toggles clearing on/off
+#event clearXTargets "<#1#> Clear XTarget#*#"
+SUB event_clearXTargets(line, ChatSender)
+  /if (!${ChatSender.Equal[${Me.Name}]}) /return
+
+  | toggle clearXTargetsOn on/off 
+  /if (!${clearXTargetsOn}) {
+    /varset clearXTargetsOn TRUE
+	/echo ClearXTargets: Enabled
+  } else {
+    /varset clearXTargetsOn FALSE
+	/echo ClearXTargets: Disabled
+  }
+/RETURN
+
+| Selects the next target and attacks
+#event nextTarget "<#1#> Next Target"
+SUB event_nextTarget(line, ChatSender)
+  /if (!${ChatSender.Equal[${Me.Name}]}) /return
+  /declare i int local
+  /declare worstAggro int local 101
+  /declare mobId int local
+  /declare mobClass string local Warrior
+  /declare mobHealth int local
+  /for i 1 to 13
+    /if (${Me.XTarget[${i}].TargetType.Equal[Auto Hater]} && (${Me.XTarget[${i}].PctAggro} < ${worstAggro} || (${Me.XTarget[${i}].PctAggro} == ${worstAggro} && ${mobClass.Equal[Warrior]} && ${Me.XTarget[${i}].PctHPs} >= ${mobHealth})) && !${Bool[${Me.XTarget[${i}].Name.Find[Corpse]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[wooden box]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[Chest]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[crate]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[hollow_tree]}]} && ${Me.XTarget[${i}].LineOfSight} && ${Me.XTarget[${i}].Distance} < 75) {
+      /varset worstAggro ${Me.XTarget[${i}].PctAggro}
+      /varset mobId ${Me.XTarget[${i}].ID}
+      /varset mobClass ${Me.XTarget[${i}].Class}
+      /varset mobHealth ${Me.XTarget[${i}].PctHPs}
+    }
+  /next i
+
+  /echo Assisting on Next Target ${Spawn[${mobId}].CleanName} TargetID=${mobId}
+  /call TrueTarget ${mobId}
+  /stick id ${mobId} 5 uw
+  /delay 1
+  /attack on
+  /delay 1
+  /assistme
+  /varset AllowControl TRUE
+  /varset AssistStickDistance 5
+/RETURN
+
+| Face the target if you can't see it
+#event faceTargetClearXTargets "You cannot see your target."
+SUB event_faceTargetClearXTargets
+    /echo ClearXTargets: Changing face direction to target ${Spawn[id ${AssistTarget}].CleanName}
+    /face fast id ${AssistTarget}    
+/RETURN
+
+| Re-stick if too far away msg   	            
+#event getCloserClearXTargets "Your target is too far away, get closer!"
+SUB event_getCloserClearXTargets
+  /echo ClearXTargets: Re-sticking to target ${Spawn[id ${AssistTarget}].CleanName}
+  /stick id ${AssistTarget} 5 uw
+/RETURN
+
+| Triggers the Next Target or disable Clear XTarget as appropriate
+SUB check_clearXTargets
+  /if (!${clearXTargetsOn}) /return
+
+  | Check if can't see target and re-stick
+  /doevent faceTargetClearXTargets
+  /doevent getCloserClearXTargets
+
+  /if (!${Assisting}) {
+    | Go through the xtargets, if there are any to kill call Next Target
+    | If there are none, disable Clear XTargets
+    /declare i int local 1
+    /for i 1 to 13
+      /if (${Me.XTarget[${i}].TargetType.Equal[Auto Hater]} && ${Me.XTarget[${i}].Aggressive}) {
+		| found a target
+        /bc Next Target
+        /return
+      }
+    /next i
+
+	| No target found, disable clearing
+    /varset clearXTargetsOn FALSE    
+    /echo ClearXTargets: XTargets Cleared, disabled Clear XTarget
+  }
+/RETURN

--- a/Macros/e3 Includes/e3_QueueCast.inc
+++ b/Macros/e3 Includes/e3_QueueCast.inc
@@ -1,0 +1,179 @@
+|--------------------------------------------------------------------------------|
+| Queue Cast
+|
+| Author: Sirhopsalot
+| Contributor: Forsy
+|
+| Queues a spell to be cast and retries with backoff times until it succeeds (or tries 4 times and a total of 15 seconds).
+| This works into the e3 casting patterns so if the toon is busy casting right now it will
+| cast at the next opportunity.
+| 
+| Usage (from any toon):
+| 	/bc ToonName queueCast SpellName targetid=TargetID
+| Usage to cast a spell with no target:
+|   /bc Flora queueCast Circle of Knowledge
+| Usage to cast a spell on a specific target:
+|   /bc Glorious queueCast Holy Elixir targetid=${Me.ID}
+|	/bc Oblivion queueCast Mind Flay targetid=${Target.ID}
+|
+| Installation:
+| 1) Put e3_QueueCast.inc in the e3 Includes folder
+| 2) In e3_Setup.inc, add: #include e3 Includes\e3_QueueCast.inc
+| 3) In Advanced Settings.ini, add: Include#20=queueCast under [Included Setups]
+|--------------------------------------------------------------------------------|
+
+|--------------------------------------------------------------------------------|
+| Declare variables used in the macro
+|--------------------------------------------------------------------------------|
+Sub queueCast_Setup
+	/declare mySpellQueue string outer
+	/declare queuedSpellTimer timer outer 0s
+/RETURN
+
+|--------------------------------------------------------------------------------|
+| Call background events and other subs required for checking the macro
+|--------------------------------------------------------------------------------|
+Sub queueCast_Background_Events
+	/doevents queueCast
+	/doevents queueCastNoTarget
+	/call castQueuedSpells
+/return
+
+| Casts the spell at the front of the queue
+SUB castQueuedSpells	
+	/if (${Defined[mySpellQueue]} && ${mySpellQueue.Length} > 1 && !${Bool[${queuedSpellTimer}]}) {
+		/call PeekStrQueue mySpellQueue
+		/declare spellArgs string local ${Macro.Return}
+		/declare spellName string local ${spellArgs.Arg[1,,]}
+		/declare spellTargetID int local ${spellArgs.Arg[2,,]}
+		| Check if SpellReady/AltAbilityReady
+		/if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]}) {
+			/call castQueuedSpell "${spellName}" ${spellTargetID}
+			/if (${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]}) {
+				/call PopStrQueue mySpellQueue
+			} else {
+				/echo QueueCast: Failed to cast ${spellName} due to ${castReturn}
+			}
+		} 
+		/if (!${castReturn.Equal[CAST_SUCCESS]}) {
+			/if (${queuedSpellTimer.OriginalValue} >= 80) {
+				/docommand ${ChatToggle} Failed to cast ${spellName} after retries
+				/call PopStrQueue mySpellQueue
+			} else /if (${Bool[${Me.Gem[${spellName}]}]} && ${Bool[${Me.GemTimer[${spellName}]}]}) {
+				| Set timer to the the cooldown time
+				/varset queuedSpellTimer ${Math.Calc[${Me.GemTimer[${spellName}]}/100]}
+			} else /if (!${Bool[${Me.Gem[${spellName}]}]} && ${Me.Book[${spellName}]}) {
+				/call memorize_spell "${spellName}" 8
+				/varset queuedSpellTimer 25
+			} else /if (${queuedSpellTimer.OriginalValue} < 80 && ${queuedSpellTimer.OriginalValue} > 0) {
+				/varset queuedSpellTimer ${Math.Calc[${queuedSpellTimer.OriginalValue}*2]}
+			} else {
+				/varset queuedSpellTimer 1s
+			}
+			/if (${queuedSpellTimer} > 0) {
+				/echo QueueCast: will retry ${spellName} again in ${Math.Calc[${queuedSpellTimer}/10]} seconds
+			}
+		}
+	}
+/RETURN
+
+| Calls e3_Cast for the given spell at the given target
+SUB castQueuedSpell(spellName, targetID)
+	/if (!${Defined[DebugQueueCast]}) /declare DebugQueueCast bool local FALSE
+	/if (${DebugQueueCast}) /echo Casting queued ${spellName} on ${Spawn[id ${targetID}].Name} TargetID=${targetID}
+
+	/declare whatToCast string local
+
+	/if (${Me.Book[${spellName}]} || ${Me.AltAbility[${spellName}]}) {
+		/varset whatToCast ${Spell[${spellName}]}
+	} else /if (${FindItemCount[=${spellName}]}) {
+		/varset whatToCast ${FindItem[=${spellName}]}
+	}
+
+	/if (${Bool[${whatToCast}]}) {
+		/if (${DebugQueueCast}) /echo whatToCast = ${whatToCast}
+		/if (${Defined[queuecastArray]}) /deletevar queuecastArray
+		/if (${Defined[queuecastArray2D]}) /deletevar queuecastArray2D
+		/declare queuecastArray[1] string outer ${whatToCast}
+		/varset queuecastArray[1] ${whatToCast}
+		/call BuildSpellArray "queuecastArray" "queuecastArray2D"
+		/call e3_Cast ${targetID} "queuecastArray2D" 1
+	}
+/RETURN
+
+| Add a spell to the queue with no targetid
+#event queueCastNoTarget "<#1#> #2# queueCast #3#"
+SUB event_queueCastNoTarget(line, ChatSender, Caster, spellName)
+	/if (!${Me.Name.Equal[${Caster}]}) /return
+	/if (${spellName.Find[targetid]}) {
+		/return
+	} 
+	/if (!${Defined[targetID]}) /declare targetID int local 0
+	/echo Queue casting ${spellName}
+
+	/call AppendStrQueue mySpellQueue "${spellName},${targetID}"
+/RETURN
+
+| Adds spells to the queue with a targetid
+#event queueCast "<#1#> #2# queueCast #3# targetid=#4#"
+SUB event_queueCast(line, ChatSender, Caster, spellName, targetID)
+	/if (!${Me.Name.Equal[${Caster}]}) /return
+	/if (!${Defined[targetID]}) /declare targetID int local 0
+	
+	/echo Queue casting ${spellName} on ${Spawn[${targetID}].CleanName}
+
+	/call AppendStrQueue mySpellQueue "${spellName},${targetID}"
+/RETURN
+
+|**
+Queue implementation
+This queue implementation is backed by a string
+**|
+
+| Used for debugging the queue methods
+#event appendString "<#1#> appendString #2# #3#"
+SUB event_appendString(line, ChatSender, variableName, newStr) 
+	/call AppendStrQueue ${variableName} "${newStr}"
+/RETURN
+
+| Used for debugging the queue methods
+#event popQueue "<#1#> popQueue #2#"
+SUB event_popQueue(line, ChatSender, variableName) 
+	/call PopStrQueue ${variableName}
+	/echo Popped ${Macro.Return}
+/RETURN
+
+| Appends the given string to the variableName string
+| will create variableName string if it doesn't exist
+| You may need to pre-declare the variableName backing string
+| in the Setup function to prevent issues with declaring outer variables
+SUB StrAppend(variableName, newStr)
+	/if (!${Defined[${variableName}]}) {
+		/declare ${variableName} string outer ${newStr}
+	} else {
+		/varset ${variableName} ${${variableName}}${newStr}
+	}
+/RETURN
+
+| Appends the given item to the queue (backed by a string value)
+SUB AppendStrQueue(variableName, newItem)
+	/if (!${Defined[queueSeparator]}) /declare queueSeparator string outer -
+	/declare strWithSep string local ${newItem}${queueSeparator} 
+	/call StrAppend ${variableName} "${strWithSep}"
+/RETURN
+
+| Peeks but does not remove the head item from the queue
+| Get the result using ${Macro.Return}
+SUB PeekStrQueue(variableName)
+/RETURN ${${variableName}.Arg[1,${queueSeparator}]}
+
+| Removes and retursn the head item from the queue
+| Get the result using ${Macro.Return}
+SUB PopStrQueue(variableName)
+	/call PeekStrQueue ${variableName}
+	/declare headValue string local ${Macro.Return}
+	/declare positionOfSecondItem int local ${Math.Calc[${${variableName}.Find[${queueSeparator}]} + 1]}
+	/declare totalLength int local ${${variableName}.Length}
+	/declare remainingLength int local ${Math.Calc[${totalLength} - ${positionOfSecondItem} + 1]}
+	/varset ${variableName} ${${variableName}.Mid[${positionOfSecondItem},${remainingLength}]}
+/RETURN ${headValue}

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -21,6 +21,8 @@
 #include e3 Includes\e3_Tanking.inc
 #include e3 Includes\e3_Utilities.inc
 #include e3 Includes\e3_Wait4Rez.inc
+#include e3 Includes\e3_QueueCast.inc
+#include e3 Includes\e3_ClearXTargets.inc
 
 #include e3 Includes\e3_Classes_Bard.inc
 #include e3 Includes\e3_Classes_Beastlord.inc

--- a/Macros/e3 Macro Inis/Advanced Settings.ini
+++ b/Macros/e3 Macro Inis/Advanced Settings.ini
@@ -35,6 +35,8 @@ Include#16=Wait4Rez
 Include#17=buy
 Include#18=alerts
 Include#19=tanking
+Include#20=queueCast
+Include#21=clearXTargets
 [Turbo]
 BRD=30
 BST=80


### PR DESCRIPTION
Queue Cast: Queues a spell to be cast and retries with backoff times
Clear XTargets: Starts assist on each of the targets in your XTarget list until they're all Cleared