### PR TITLE
Adds Med Break Character Options

### DIFF
--- a/Macros/e3 Includes/e3.mac
+++ b/Macros/e3 Includes/e3.mac
@@ -1,0 +1,94 @@
+|---------------------------------------------------|
+|- e3.mac	v7.0				                             -|
+|- Originally written by Killians of PEQ.	         -|
+|- Enhanced and maintained by Creamo of PEQ.       -|
+|- Thanks to Vysra for IDE,additional plugins,code -|
+|---------------------------------------------------|
+|#warning
+#turbo 100
+#include e3 Includes\e3_Setup.inc
+
+SUB Main(modeSelect)
+  /declare macroVersion string outer 7.0
+  /declare Debug bool outer false
+  /declare IniMode string outer Ini
+  /if (${Bool[${Plugin[MQ2IniExt]}]}) {
+    /varset IniMode IniExt
+    /iniext clear
+  }
+  /call e3_Setup "${modeSelect}"
+	/if (${Debug}) {
+		/echo Post Setup
+		/delay 5
+	}
+  /declare i int local
+
+:MainLoop
+/if (${Debug}) /echo |- MainLoop ==>
+		/varset ActionTaken FALSE
+		/call check_Active
+		/call check_Idle
+    /call check_autoTribute
+    /if (${currentZone} != ${Zone.ID})  /call check_Zone
+    /if (${Following} && !${Assisting}) /call check_Follow
+
+		/if (${Defined[lifeSupport2D]} && ${Me.PctHPs} < 99) /call check_lifeSupport
+    |workaround for item cast array
+    /if (${reloadOnLoot}) /call reloadSpellArrays
+
+		/call Background_Events
+		| If I'm not active, call mainFunctions
+		/if (!${activeTimer}) {
+      |These are functions in the e3_setup/Advanced.ini class sections... ex CLR Function#1=check_DivineArb
+			/for i 1 to ${mainLoop_Array.Size}
+				/if (${Bool[${mainLoop_Array[${i}]}]}) /call ${mainLoop_Array[${i}]}
+			/if (!${ActionTaken}) /next i
+
+      /if (${Me.CombatState.NotEqual[COMBAT]}) {
+        /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && !${use_TargetAE}) /call completePendingExchange
+        /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
+          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana})) {
+            /varset medBreak TRUE
+			/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
+          }
+        }
+      }
+      /if (${medBreak}) /call check_MedBreak
+		}
+
+  /if (${MoveUtils.GM}) {
+    /squelch /stick imsafe
+    /echo GM Safe kicked in, issued /stick imsafe.  you may need to reissue /followme or /assiston
+  }
+/if (${Debug}) {
+	/echo <== MainLoop -|
+	/delay 5
+}
+/goto :MainLoop	
+/RETURN
+
+|----------------------------------------------------------------------------------------------------------------|
+|- Background events and functions that are checked even while casting or otherwise considered active.		   		-|
+|- This function is checked constantly, included events and functions should have minimal character interaction.-|
+|- These are functions in the e3_setup Included Setups section
+SUB Background_Events
+	/declare i int local
+	/for i 1 to ${macroSetups.Size}
+		/if (${Bool[${macroSetups[${i}]}]}) /call ${macroSetups[${i}]}_Background_Events
+  /next i
+/RETURN
+
+|----------------------------------------------------------------------------------------------------------------|
+|- this handles removing and readding of items from spell arrays, ie when you die
+|- criteria to reload = wearing a chest and having >=1 platinum
+SUB reloadSpellArrays
+  /if (${Bool[${FindItem[=${missingSpellItem}].ID}]}) {
+    /varset reloadOnLoot FALSE
+    /varset missingSpellItem 0
+    /call buff_SpellArrays
+    /call heal_SpellArrays
+    /call assist_SpellArrays
+    /call pet_spellArrays
+    /call cure_spellArrays
+  }
+/RETURN

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1013,6 +1013,7 @@ SUB EVENT_medOn(line, ChatSender)
   /if (${Me.Class.ShortName.NotEqual[BRD]}) {
       /docommand ${ChatToggle} Meditating...
       /varset medBreak TRUE
+	  /if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
       /if (${line.Find[ Hold]}) {
         /varset medBreak_Hold TRUE
       } else {
@@ -1033,6 +1034,7 @@ SUB EVENT_medOff(line, ChatSender)
     /docommand ${ChatToggle} Ending Medbreak.
     /varset medBreak FALSE
     /varset medBreak_Hold FALSE
+	/if (${Ini[${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)].Length}) /call iniToVarV "${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)" AssistType string outer
     /if (${Me.Sitting}) /stand
   }
 /if (${Debug} || ${Debug_Basics}) /echo <== EVENT_medOff -|
@@ -1044,11 +1046,12 @@ SUB EVENT_medOff(line, ChatSender)
 |--------------------------------------------------------------------------------|
 SUB check_MedBreak
 /if (${Debug} || ${Debug_Basics}) /echo |- check_MedBreak ==>
-	| If End MedBreak in Combat (On/Off)=On, and a netbot is in combat, call medOff
-	/if (${medOn_combatBreak} && ${Me.CombatState.Equal[COMBAT]}) {
-    /docommand ${ChatToggle} Ending Medbreak.
+	| If End MedBreak in Combat (On/Off)=On in General and Character, and a netbot is in combat, call medOff
+	/if (${medOn_combatBreak} && ${medOn_combatBreakChar} && ${Me.CombatState.Equal[COMBAT]}) {
+    /docommand ${ChatToggle} Ending Medbreak early due to combat.
     /varset medBreak FALSE
     /varset medBreak_Hold FALSE
+	/if (${Ini[${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)].Length}) /call iniToVarV "${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)" AssistType string outer
     /if (${Me.Sitting}) /stand
 	}
 	/if (!${Me.Feigning}) {
@@ -1061,7 +1064,8 @@ SUB check_MedBreak
 			/docommand ${ChatToggle} Full Mana/Endurance, ending MedBreak.
 			/if (${Me.Sitting}) /stand
 			/varset medBreak FALSE
-			/varset medBreak_Hold FALSE				
+			/varset medBreak_Hold FALSE	
+			/if (${Ini[${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)].Length}) /call iniToVarV "${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)" AssistType string outer			
 		} else {
       /if (!${Me.Sitting} && !${Me.Casting.ID} && !${Me.Moving}) /sit
 		}
@@ -1514,6 +1518,8 @@ Sub basics_Setup
 
 	/declare medBreak bool outer FALSE
 	/declare medBreak_Hold bool outer FALSE
+	/declare medOn_combatBreak bool outer FALSE
+	/declare autoMedChar bool outer FALSE
 	/declare medbreak_Popup_Timer timer outer
 	/declare clickitRandomDelay int outer 7
 
@@ -1528,7 +1534,9 @@ Sub basics_Setup
 	/declare LeashLength int outer 100
 	/if (${Ini[${genSettings_Ini},General,Leash Length].Length} && ${Int[${Ini[${genSettings_Ini},General,Leash Length]}]}) /call iniToVarV "${genSettings_Ini},General,Leash Length" LeashLength int outer
 	/if (${Ini[${genSettings_Ini},General,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${genSettings_Ini},General,End MedBreak in Combat(On/Off)" medOn_combatBreak bool outer
-  /if (${Ini[${genSettings_Ini},General,AutoMedBreak PctMana].Length}) /call iniToVarV "${genSettings_Ini},General,AutoMedBreak PctMana" autoMedPctMana int outer
+	/if (${Ini[${genSettings_Ini},General,AutoMedBreak PctMana].Length}) /call iniToVarV "${genSettings_Ini},General,AutoMedBreak PctMana" autoMedPctMana int outer
+  	/if (${Ini[${Character_Ini},Misc,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" medOn_combatBreakChar bool outer
+	/if (${Ini[${Character_Ini},Misc,AutoMedBreak (On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,AutoMedBreak (On/Off)" autoMedChar bool outer
 	| -Add Groups_Ini file path
 	/if (!${Ini[${MacroData_Ini},File Paths,Saved Groups].Length}) /call WriteToIni "${MacroData_Ini},File Paths,Saved Groups" "e3 Macro Inis\Saved Groups.ini" 1
 	| -Import Groups_Ini.

--- a/Macros/e3 Includes/e3_Classes_Beastlord.inc
+++ b/Macros/e3 Includes/e3_Classes_Beastlord.inc
@@ -40,6 +40,8 @@ Sub BST_Background_Events
 /return
 |----------------------------------------------------------------------------|
 SUB BST_CharacterSettings
+/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BST_Aliases

--- a/Macros/e3 Includes/e3_Classes_Berserker.inc
+++ b/Macros/e3 Includes/e3_Classes_Berserker.inc
@@ -40,6 +40,8 @@ SUB BER_MacroSettings
 |----------------------------------------------------------------------------|
 SUB BER_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},Axe Ability" "Axe of the Destroyer/Reagent|Balanced Axe Components/CheckFor|20"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BER_Aliases

--- a/Macros/e3 Includes/e3_Classes_Cleric.inc
+++ b/Macros/e3 Includes/e3_Classes_Cleric.inc
@@ -378,6 +378,8 @@ SUB CLR_CharacterSettings
   /call WriteToIni "${Character_Ini},Cleric,Yaulp Spell"
   /call WriteToIni "${Character_Ini},Cleric,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Cleric,Summoned Pet Hammer"
+  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== CLR_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Druid.inc
+++ b/Macros/e3 Includes/e3_Classes_Druid.inc
@@ -20,6 +20,8 @@ SUB DRU_MacroSettings
 |----------------------------------------------------------------------------|
 SUB DRU_CharacterSettings
 	/call WriteToIni "${Character_Ini},Druid,Evac Spell"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub DRU_Aliases

--- a/Macros/e3 Includes/e3_Classes_Enchanter.inc
+++ b/Macros/e3 Includes/e3_Classes_Enchanter.inc
@@ -307,6 +307,8 @@ SUB ENC_CharacterSettings
   /call WriteToIni "${Character_Ini},Enchanter,Mez"
 	/call WriteToIni "${Character_Ini},Enchanter,Charm"
   /call WriteToIni "${Character_Ini},Enchanter,GatherMana Pct" 10
+  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub ENC_Aliases

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -305,6 +305,8 @@ SUB MAG_CharacterSettings
 	/call WriteToIni "${Character_Ini},Magician,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Magician,Auto-Summon Orb of Mastery (On/Off)"
 	/call WriteToIni "${Character_Ini},Magician,Summoned Pet Item"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== MAG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Monk.inc
+++ b/Macros/e3 Includes/e3_Classes_Monk.inc
@@ -27,6 +27,8 @@ SUB MNK_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB MNK_CharacterSettings
+/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub MNK_Aliases

--- a/Macros/e3 Includes/e3_Classes_Necromancer.inc
+++ b/Macros/e3 Includes/e3_Classes_Necromancer.inc
@@ -117,6 +117,8 @@ SUB NEC_CharacterSettings
   |/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump Engage Pct" 70
 	/call WriteToIni "${Character_Ini},${Me.Class},Who to Mana Dump"
 	/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== NEC_CharacterSettings -|
 /return
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Paladin.inc
+++ b/Macros/e3 Includes/e3_Classes_Paladin.inc
@@ -25,7 +25,8 @@ SUB PAL_CharacterSettings
 /if (${Debug}) /echo |- PAL_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Paladin,Auto-Yaulp (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Paladin,Yaulp Spell"
-
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== PAL_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Ranger.inc
+++ b/Macros/e3 Includes/e3_Classes_Ranger.inc
@@ -23,6 +23,8 @@ SUB RNG_MacroSettings
 |----------------------------------------------------------------------------|
 SUB RNG_CharacterSettings
   /call WriteToIni "${Character_Ini},${Me.Class},TargetAE Ranged (On/Off)" Off
+  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /return
 |----------------------------------------------------------------------------|
 Sub RNG_Aliases

--- a/Macros/e3 Includes/e3_Classes_Rogue.inc
+++ b/Macros/e3 Includes/e3_Classes_Rogue.inc
@@ -86,6 +86,8 @@ SUB ROG_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonPR" "Bite of the Shissar XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonFR" "Solusek's Burn XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonCR" "E`ci's Lament XII"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 	/if (${Debug}) /echo <== ROG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
+++ b/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
@@ -22,6 +22,8 @@ SUB SHD_MacroSettings
 SUB SHD_CharacterSettings
 /if (${Debug}) /echo |- SHD_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},${Me.Class},LifeTap"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHD_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Shaman.inc
+++ b/Macros/e3 Includes/e3_Classes_Shaman.inc
@@ -53,6 +53,8 @@ SUB SHM_CharacterSettings
 /if (${Debug}) /echo |- SHM_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Shaman,Auto-Canni (On/Off)"
 	/call WriteToIni "${Character_Ini},Shaman,Canni"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHM_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Warrior.inc
+++ b/Macros/e3 Includes/e3_Classes_Warrior.inc
@@ -14,6 +14,8 @@ SUB WAR_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB WAR_CharacterSettings
+/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub WAR_Aliases

--- a/Macros/e3 Includes/e3_Classes_Wizard.inc
+++ b/Macros/e3 Includes/e3_Classes_Wizard.inc
@@ -43,6 +43,8 @@ SUB WIZ_CharacterSettings
 	/call WriteToIni "${Character_Ini},Wizard,Evac Spell"
 	/call WriteToIni "${Character_Ini},Wizard,Auto-Harvest (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Wizard,Harvest"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== WIZ_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|


### PR DESCRIPTION
Added auto med break options by character. Also makes casters stop sticking in combat while medding. Auto med breaks are off by default.

To add the options to your character, edit your character ini and insert the following lines under [Misc]:

End MedBreak in Combat(On/Off)=On
AutoMedBreak (On/Off)=Off

Change accordingly. AutoMedBreak will honor your AutoMedBreak ManaPct setting in General Settings.ini and End MedBreak in Combat will similarly honor your setting in General Settings.ini (similar to Auto Loot)

Changes nothing about bards as they have multiple definitions in the macro set to completely ignore medbreak.