### PR TITLE
Class.inc revert. Bug fixes. AutoMedBreak behavior change.

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1620,6 +1620,9 @@ SUB basics_MacroSettings
 /RETURN
 
 SUB basics_CharacterSettings
+/if ((${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off else /if (${Me.Class.ShortName.NotEqual[BRD]}) /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+
+/if (${Me.Class.ShortName.NotEqual[BRD]}) /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 
 Sub basics_Aliases

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1013,6 +1013,7 @@ SUB EVENT_medOn(line, ChatSender)
   /if (${Me.Class.ShortName.NotEqual[BRD]}) {
       /docommand ${ChatToggle} Meditating...
       /varset medBreak TRUE
+	  /if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
       /if (${line.Find[ Hold]}) {
         /varset medBreak_Hold TRUE
       } else {
@@ -1033,6 +1034,7 @@ SUB EVENT_medOff(line, ChatSender)
     /docommand ${ChatToggle} Ending Medbreak.
     /varset medBreak FALSE
     /varset medBreak_Hold FALSE
+	/if (${Ini[${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)].Length}) /call iniToVarV "${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)" AssistType string outer
     /if (${Me.Sitting}) /stand
   }
 /if (${Debug} || ${Debug_Basics}) /echo <== EVENT_medOff -|
@@ -1044,11 +1046,12 @@ SUB EVENT_medOff(line, ChatSender)
 |--------------------------------------------------------------------------------|
 SUB check_MedBreak
 /if (${Debug} || ${Debug_Basics}) /echo |- check_MedBreak ==>
-	| If End MedBreak in Combat (On/Off)=On, and a netbot is in combat, call medOff
-	/if (${medOn_combatBreak} && ${Me.CombatState.Equal[COMBAT]}) {
-    /docommand ${ChatToggle} Ending Medbreak.
+	| If End MedBreak in Combat (On/Off)=On in General and Character, and a netbot is in combat, call medOff
+	/if (${medOn_combatBreak} && ${medOn_combatBreakChar} && ${Me.CombatState.Equal[COMBAT]}) {
+    /docommand ${ChatToggle} Ending Medbreak early due to combat.
     /varset medBreak FALSE
     /varset medBreak_Hold FALSE
+	/if (${Ini[${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)].Length}) /call iniToVarV "${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)" AssistType string outer
     /if (${Me.Sitting}) /stand
 	}
 	/if (!${Me.Feigning}) {
@@ -1061,7 +1064,8 @@ SUB check_MedBreak
 			/docommand ${ChatToggle} Full Mana/Endurance, ending MedBreak.
 			/if (${Me.Sitting}) /stand
 			/varset medBreak FALSE
-			/varset medBreak_Hold FALSE				
+			/varset medBreak_Hold FALSE	
+			/if (${Ini[${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)].Length}) /call iniToVarV "${Character_Ini},Assist Settings,Assist Type (Melee/Ranged/Off)" AssistType string outer			
 		} else {
       /if (!${Me.Sitting} && !${Me.Casting.ID} && !${Me.Moving}) /sit
 		}
@@ -1514,6 +1518,8 @@ Sub basics_Setup
 
 	/declare medBreak bool outer FALSE
 	/declare medBreak_Hold bool outer FALSE
+	/declare medOn_combatBreak bool outer FALSE
+	/declare autoMedChar bool outer FALSE
 	/declare medbreak_Popup_Timer timer outer
 	/declare clickitRandomDelay int outer 7
 
@@ -1528,7 +1534,9 @@ Sub basics_Setup
 	/declare LeashLength int outer 100
 	/if (${Ini[${genSettings_Ini},General,Leash Length].Length} && ${Int[${Ini[${genSettings_Ini},General,Leash Length]}]}) /call iniToVarV "${genSettings_Ini},General,Leash Length" LeashLength int outer
 	/if (${Ini[${genSettings_Ini},General,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${genSettings_Ini},General,End MedBreak in Combat(On/Off)" medOn_combatBreak bool outer
-  /if (${Ini[${genSettings_Ini},General,AutoMedBreak PctMana].Length}) /call iniToVarV "${genSettings_Ini},General,AutoMedBreak PctMana" autoMedPctMana int outer
+	/if (${Ini[${genSettings_Ini},General,AutoMedBreak PctMana].Length}) /call iniToVarV "${genSettings_Ini},General,AutoMedBreak PctMana" autoMedPctMana int outer
+  	/if (${Ini[${Character_Ini},Misc,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" medOn_combatBreakChar bool outer
+	/if (${Ini[${Character_Ini},Misc,AutoMedBreak (On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,AutoMedBreak (On/Off)" autoMedChar bool outer
 	| -Add Groups_Ini file path
 	/if (!${Ini[${MacroData_Ini},File Paths,Saved Groups].Length}) /call WriteToIni "${MacroData_Ini},File Paths,Saved Groups" "e3 Macro Inis\Saved Groups.ini" 1
 	| -Import Groups_Ini.

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1620,8 +1620,11 @@ SUB basics_MacroSettings
 /RETURN
 
 SUB basics_CharacterSettings
-/if ((${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off else /if (${Me.Class.ShortName.NotEqual[BRD]}) /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-
+/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) {
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+} else /if (${Me.Class.ShortName.NotEqual[BRD]}) {
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+}
 /if (${Me.Class.ShortName.NotEqual[BRD]}) /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 

--- a/Macros/e3 Includes/e3_Classes_Beastlord.inc
+++ b/Macros/e3 Includes/e3_Classes_Beastlord.inc
@@ -40,8 +40,6 @@ Sub BST_Background_Events
 /return
 |----------------------------------------------------------------------------|
 SUB BST_CharacterSettings
-/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BST_Aliases

--- a/Macros/e3 Includes/e3_Classes_Beastlord.inc
+++ b/Macros/e3 Includes/e3_Classes_Beastlord.inc
@@ -40,6 +40,8 @@ Sub BST_Background_Events
 /return
 |----------------------------------------------------------------------------|
 SUB BST_CharacterSettings
+/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BST_Aliases

--- a/Macros/e3 Includes/e3_Classes_Berserker.inc
+++ b/Macros/e3 Includes/e3_Classes_Berserker.inc
@@ -40,6 +40,8 @@ SUB BER_MacroSettings
 |----------------------------------------------------------------------------|
 SUB BER_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},Axe Ability" "Axe of the Destroyer/Reagent|Balanced Axe Components/CheckFor|20"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BER_Aliases

--- a/Macros/e3 Includes/e3_Classes_Berserker.inc
+++ b/Macros/e3 Includes/e3_Classes_Berserker.inc
@@ -40,8 +40,6 @@ SUB BER_MacroSettings
 |----------------------------------------------------------------------------|
 SUB BER_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},Axe Ability" "Axe of the Destroyer/Reagent|Balanced Axe Components/CheckFor|20"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub BER_Aliases

--- a/Macros/e3 Includes/e3_Classes_Cleric.inc
+++ b/Macros/e3 Includes/e3_Classes_Cleric.inc
@@ -378,6 +378,8 @@ SUB CLR_CharacterSettings
   /call WriteToIni "${Character_Ini},Cleric,Yaulp Spell"
   /call WriteToIni "${Character_Ini},Cleric,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Cleric,Summoned Pet Hammer"
+  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== CLR_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Cleric.inc
+++ b/Macros/e3 Includes/e3_Classes_Cleric.inc
@@ -378,8 +378,6 @@ SUB CLR_CharacterSettings
   /call WriteToIni "${Character_Ini},Cleric,Yaulp Spell"
   /call WriteToIni "${Character_Ini},Cleric,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Cleric,Summoned Pet Hammer"
-  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== CLR_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Druid.inc
+++ b/Macros/e3 Includes/e3_Classes_Druid.inc
@@ -20,6 +20,8 @@ SUB DRU_MacroSettings
 |----------------------------------------------------------------------------|
 SUB DRU_CharacterSettings
 	/call WriteToIni "${Character_Ini},Druid,Evac Spell"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub DRU_Aliases

--- a/Macros/e3 Includes/e3_Classes_Druid.inc
+++ b/Macros/e3 Includes/e3_Classes_Druid.inc
@@ -20,8 +20,6 @@ SUB DRU_MacroSettings
 |----------------------------------------------------------------------------|
 SUB DRU_CharacterSettings
 	/call WriteToIni "${Character_Ini},Druid,Evac Spell"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub DRU_Aliases

--- a/Macros/e3 Includes/e3_Classes_Enchanter.inc
+++ b/Macros/e3 Includes/e3_Classes_Enchanter.inc
@@ -307,8 +307,6 @@ SUB ENC_CharacterSettings
   /call WriteToIni "${Character_Ini},Enchanter,Mez"
 	/call WriteToIni "${Character_Ini},Enchanter,Charm"
   /call WriteToIni "${Character_Ini},Enchanter,GatherMana Pct" 10
-  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub ENC_Aliases

--- a/Macros/e3 Includes/e3_Classes_Enchanter.inc
+++ b/Macros/e3 Includes/e3_Classes_Enchanter.inc
@@ -307,6 +307,8 @@ SUB ENC_CharacterSettings
   /call WriteToIni "${Character_Ini},Enchanter,Mez"
 	/call WriteToIni "${Character_Ini},Enchanter,Charm"
   /call WriteToIni "${Character_Ini},Enchanter,GatherMana Pct" 10
+  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub ENC_Aliases

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -305,6 +305,8 @@ SUB MAG_CharacterSettings
 	/call WriteToIni "${Character_Ini},Magician,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Magician,Auto-Summon Orb of Mastery (On/Off)"
 	/call WriteToIni "${Character_Ini},Magician,Summoned Pet Item"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== MAG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -305,8 +305,6 @@ SUB MAG_CharacterSettings
 	/call WriteToIni "${Character_Ini},Magician,Auto-Pet Weapons (On/Off)"
   /call WriteToIni "${Character_Ini},Magician,Auto-Summon Orb of Mastery (On/Off)"
 	/call WriteToIni "${Character_Ini},Magician,Summoned Pet Item"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== MAG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Monk.inc
+++ b/Macros/e3 Includes/e3_Classes_Monk.inc
@@ -27,8 +27,6 @@ SUB MNK_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB MNK_CharacterSettings
-/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub MNK_Aliases

--- a/Macros/e3 Includes/e3_Classes_Monk.inc
+++ b/Macros/e3 Includes/e3_Classes_Monk.inc
@@ -27,6 +27,8 @@ SUB MNK_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB MNK_CharacterSettings
+/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub MNK_Aliases

--- a/Macros/e3 Includes/e3_Classes_Necromancer.inc
+++ b/Macros/e3 Includes/e3_Classes_Necromancer.inc
@@ -117,6 +117,8 @@ SUB NEC_CharacterSettings
   |/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump Engage Pct" 70
 	/call WriteToIni "${Character_Ini},${Me.Class},Who to Mana Dump"
 	/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== NEC_CharacterSettings -|
 /return
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Necromancer.inc
+++ b/Macros/e3 Includes/e3_Classes_Necromancer.inc
@@ -117,8 +117,6 @@ SUB NEC_CharacterSettings
   |/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump Engage Pct" 70
 	/call WriteToIni "${Character_Ini},${Me.Class},Who to Mana Dump"
 	/call WriteToIni "${Character_Ini},${Me.Class},Mana Dump"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== NEC_CharacterSettings -|
 /return
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Paladin.inc
+++ b/Macros/e3 Includes/e3_Classes_Paladin.inc
@@ -25,7 +25,8 @@ SUB PAL_CharacterSettings
 /if (${Debug}) /echo |- PAL_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Paladin,Auto-Yaulp (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Paladin,Yaulp Spell"
-
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== PAL_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Paladin.inc
+++ b/Macros/e3 Includes/e3_Classes_Paladin.inc
@@ -25,8 +25,6 @@ SUB PAL_CharacterSettings
 /if (${Debug}) /echo |- PAL_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Paladin,Auto-Yaulp (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Paladin,Yaulp Spell"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== PAL_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Ranger.inc
+++ b/Macros/e3 Includes/e3_Classes_Ranger.inc
@@ -23,8 +23,6 @@ SUB RNG_MacroSettings
 |----------------------------------------------------------------------------|
 SUB RNG_CharacterSettings
   /call WriteToIni "${Character_Ini},${Me.Class},TargetAE Ranged (On/Off)" Off
-  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /return
 |----------------------------------------------------------------------------|
 Sub RNG_Aliases

--- a/Macros/e3 Includes/e3_Classes_Ranger.inc
+++ b/Macros/e3 Includes/e3_Classes_Ranger.inc
@@ -23,6 +23,8 @@ SUB RNG_MacroSettings
 |----------------------------------------------------------------------------|
 SUB RNG_CharacterSettings
   /call WriteToIni "${Character_Ini},${Me.Class},TargetAE Ranged (On/Off)" Off
+  /call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+  /call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /return
 |----------------------------------------------------------------------------|
 Sub RNG_Aliases

--- a/Macros/e3 Includes/e3_Classes_Rogue.inc
+++ b/Macros/e3 Includes/e3_Classes_Rogue.inc
@@ -86,6 +86,8 @@ SUB ROG_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonPR" "Bite of the Shissar XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonFR" "Solusek's Burn XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonCR" "E`ci's Lament XII"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 	/if (${Debug}) /echo <== ROG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Rogue.inc
+++ b/Macros/e3 Includes/e3_Classes_Rogue.inc
@@ -86,8 +86,6 @@ SUB ROG_CharacterSettings
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonPR" "Bite of the Shissar XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonFR" "Solusek's Burn XII"
 	/call WriteToIni "${Character_Ini},${Me.Class},PoisonCR" "E`ci's Lament XII"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 	/if (${Debug}) /echo <== ROG_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
+++ b/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
@@ -22,6 +22,8 @@ SUB SHD_MacroSettings
 SUB SHD_CharacterSettings
 /if (${Debug}) /echo |- SHD_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},${Me.Class},LifeTap"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHD_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
+++ b/Macros/e3 Includes/e3_Classes_ShadowKnight.inc
@@ -22,8 +22,6 @@ SUB SHD_MacroSettings
 SUB SHD_CharacterSettings
 /if (${Debug}) /echo |- SHD_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},${Me.Class},LifeTap"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHD_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Shaman.inc
+++ b/Macros/e3 Includes/e3_Classes_Shaman.inc
@@ -53,8 +53,6 @@ SUB SHM_CharacterSettings
 /if (${Debug}) /echo |- SHM_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Shaman,Auto-Canni (On/Off)"
 	/call WriteToIni "${Character_Ini},Shaman,Canni"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHM_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Shaman.inc
+++ b/Macros/e3 Includes/e3_Classes_Shaman.inc
@@ -53,6 +53,8 @@ SUB SHM_CharacterSettings
 /if (${Debug}) /echo |- SHM_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},Shaman,Auto-Canni (On/Off)"
 	/call WriteToIni "${Character_Ini},Shaman,Canni"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== SHM_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Warrior.inc
+++ b/Macros/e3 Includes/e3_Classes_Warrior.inc
@@ -14,6 +14,8 @@ SUB WAR_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB WAR_CharacterSettings
+/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
+/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub WAR_Aliases

--- a/Macros/e3 Includes/e3_Classes_Warrior.inc
+++ b/Macros/e3 Includes/e3_Classes_Warrior.inc
@@ -14,8 +14,6 @@ SUB WAR_MacroSettings
 /RETURN
 |----------------------------------------------------------------------------|
 SUB WAR_CharacterSettings
-/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" On
-/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /RETURN
 |----------------------------------------------------------------------------|
 Sub WAR_Aliases

--- a/Macros/e3 Includes/e3_Classes_Wizard.inc
+++ b/Macros/e3 Includes/e3_Classes_Wizard.inc
@@ -43,8 +43,6 @@ SUB WIZ_CharacterSettings
 	/call WriteToIni "${Character_Ini},Wizard,Evac Spell"
 	/call WriteToIni "${Character_Ini},Wizard,Auto-Harvest (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Wizard,Harvest"
-	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
-	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== WIZ_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Wizard.inc
+++ b/Macros/e3 Includes/e3_Classes_Wizard.inc
@@ -43,6 +43,8 @@ SUB WIZ_CharacterSettings
 	/call WriteToIni "${Character_Ini},Wizard,Evac Spell"
 	/call WriteToIni "${Character_Ini},Wizard,Auto-Harvest (On/Off)" Off
 	/call WriteToIni "${Character_Ini},Wizard,Harvest"
+	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
+	/call WriteToIni "${Character_Ini},Misc,AutoMedBreak (On/Off)" Off
 /if (${Debug}) /echo <== WIZ_CharacterSettings -|
 /RETURN
 |----------------------------------------------------------------------------|

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -50,9 +50,9 @@ SUB Main(modeSelect)
           /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana} && ${autoMedChar})) {
             /varset medBreak TRUE
 			/if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) {
-			/varset AssistType Off 
+			  /varset AssistType Off 
 			} else {
-			/declare AssistType string Off
+			  /declare AssistType string Off
 			}
           }
         }

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -49,7 +49,7 @@ SUB Main(modeSelect)
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
           /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1) || (${Me.PctEndurance} < ${autoMedPctMana}) && ${autoMedChar}) {
             /varset medBreak TRUE
-			/if (${Defined[AssistType]}) (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off else /declare AssistType string Off
+			/if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) /varset AssistType Off else /declare AssistType string Off
           }
         }
       }

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -47,7 +47,7 @@ SUB Main(modeSelect)
       /if (${Me.CombatState.NotEqual[COMBAT]}) {
         /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && !${use_TargetAE}) /call completePendingExchange
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
-          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana})) {
+          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1) || (${Me.PctEndurance} < ${autoMedPctMana}) && ${autoMedChar}) {
             /varset medBreak TRUE
 			/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
           }

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -47,7 +47,7 @@ SUB Main(modeSelect)
       /if (${Me.CombatState.NotEqual[COMBAT]}) {
         /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && !${use_TargetAE}) /call completePendingExchange
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
-          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1) || (${Me.PctEndurance} < ${autoMedPctMana}) && ${autoMedChar}) {
+          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana} && ${autoMedChar})) {
             /varset medBreak TRUE
 			/if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) /varset AssistType Off else /declare AssistType string Off
           }

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -47,8 +47,9 @@ SUB Main(modeSelect)
       /if (${Me.CombatState.NotEqual[COMBAT]}) {
         /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && !${use_TargetAE}) /call completePendingExchange
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
-          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1) || (${Me.PctEndurance} < ${autoMedPctMana})) {
+          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana})) {
             /varset medBreak TRUE
+			/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
           }
         }
       }

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -49,7 +49,11 @@ SUB Main(modeSelect)
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
           /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana} && ${autoMedChar})) {
             /varset medBreak TRUE
-			/if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) /varset AssistType Off else /declare AssistType string Off
+			/if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) {
+			/varset AssistType Off 
+			} else {
+			/declare AssistType string Off
+			}
           }
         }
       }

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -49,7 +49,7 @@ SUB Main(modeSelect)
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
           /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1) || (${Me.PctEndurance} < ${autoMedPctMana}) && ${autoMedChar}) {
             /varset medBreak TRUE
-			/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
+			/if (${Defined[AssistType]}) (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off else /declare AssistType string Off
           }
         }
       }

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -47,7 +47,7 @@ SUB Main(modeSelect)
       /if (${Me.CombatState.NotEqual[COMBAT]}) {
         /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && !${use_TargetAE}) /call completePendingExchange
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
-          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1) || (${Me.PctEndurance} < ${autoMedPctMana}) && ${autoMedChar}) {
+          /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana})) {
             /varset medBreak TRUE
 			/if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) /varset AssistType Off
           }


### PR DESCRIPTION
Reverting the changes done to the class.inc files and moving it to a single set of writes in basics.inc.

Made the behavior for mana and end uniform for AutoMedBreak.

Fixed an issue with new characters when AssistType isn't declared yet.