### PR TITLE
Fixed Gimme DC with new Alt Currency in Emu

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1771,7 +1771,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/delay 5s ${Window[InventoryWindow].Open}
 		/notify InventoryWindow IW_Subwindows tabselect 5
 		/delay 1s
-		/notify InventoryWindow AltCurr_PointList listselect 4
+		/notify InventoryWindow AltCurr_PointList listselect 8
 		/delay 1s
 		/notify InventoryWindow IW_AltCurr_ReclaimButton leftmouseup
 		/delay 1s


### PR DESCRIPTION
With new currencies added in EQEmu, Gimme DC was unable to select Diamond Coin in the Alt Currencies tab. Just had to update the line ID so it would work again.