### PR TITLE
Major Release From Rekka & Ewiclip

### DIFF
--- a/Macros/e3 Changelog.txt
+++ b/Macros/e3 Changelog.txt
@@ -1,41 +1,77 @@
 --------- To Dos:
+	- Modify DoT code to apply /MaxTries|# to TriggerSpells
+	- Migrate "Smart Taunt" to use E3_Cast now that this function has been drastically improved
+	- Update gimme to allow alias of items
+	- Rework /AERez
+	- Rework /quickburns, /fullburns /longburns & /epicburns to fire faster
+	
+===============================================================================================================================================================================================
+===============================================================================================================================================================================================
 
-. Create a default routes file, with routes from the guild lobby to common destinations
+v5.1 r9 Change log:
+--------- Fixed:
+	- When using Gimme to your mage for Mod Shards, characters will no longer will disconnect if they are in the middle of a cast. 
+	***NOTE*** If you use /itemnotify <item> leftmouseup while casting, your toon will DC! Avoid this with customizations!
+	- Gimme large shard delete feature now works with all versions of Mod Shards 
+	- Self Mod Shard for Supply mage now works
+	- Fix for /GoM on spells in the nuke section. This should work properly now.
+	- Gimme will now recast on fizzles and uses BC tells instead of /tell for group members.
+	- Gimme will use e3_Cast now instead of raw /cast function
+--------- Changed:
+	- Optimizations for BuildSpellArray. Originally BuildSpellArray was for one time builds for spell casts at initial startup and the results saved and thus speed wasn't an important consideration. 
+		> However the new method castSimpleSpellArray uses BuildSpellArray and thus a passthrough was neeeded. Entire method was reworked and reorganized. Over 140+ conditionals/checks/method calls removed in most circumstances.
+	- /ClickIt will now dismount and call /stopcast before *IF* you are in the middle of a spell cast before clicking. This helps prevent crashes related to casting-while-initiating a zone
+	- /SwarmPets changes:
+		> Swarm Pets now trigger significantly quicker than before
+		> Necromancer AA 'Rise of Bones' is correctly added to the swarpPets array when you own the AA
+		> Necromancer Epic 1.5 / 2.0 are both now included as a swarm pet
+		> Graverobber's Icon from HCUR is now included as a swarm pet
+		> Necromancer "Wake the Dead" has been REMOVED from /SwarmPets because it is known to cause zone crashes. You can still include it in other parts of your INI like Burns at your own risk.
+	- Old #inst add code has been completely removed.
+--------- Added:
+	- New Magician feature for gearing group pets automatically (details below)
+	- A timer on nukes was created to prevent an item from being 'attempted' to be cast mutiple times even if it was on cooldown. 
+		> E3 would cast the item, then loop back around and it would see the item as a valid cast again as "cooldown" would not be set yet. 
+		> Now a 1 second timer is created for any item based nuke to give time for the client to get the updated value and start the items cooldown.  
+		> This probably should be done in other areas but at the time I was testing Molten Orb from the mage.
+	- Players can now send the expedition leader a tell saying "dzadd" to automatically get invites. 
+	***EXAMPLE*** "/t Ewiclip dzadd" (single player) or "/bcaa //t Ewiclip dzadd" (all eqbcs players)
+	- Necromancer "Orb of Shadows" and "Orb of Souls" will now automatically cast on Tank Heals and XTarget Heal if the target is below 90% HP immediately following a heal. This can be toggled on/off inside the Heal Section of the INI. This feature is ON by default. 
+	***NOTE*** E3 WILL NOT BEEP IF YOU'RE OUT OF ORBS. It is completely up to you to ensure your healers have orbs in their inventory if you'd like to use this feature. 
+	- castSimpleSpell "spellName" "targetid"
+	> This will use e3 Cast but is far simpler to use. Used for spells that are non combat related and you don't expect to fail
+		Stop using /casting please :)
+	- notifyViaBCTell  ${ChatSender} "Message"
+		> this will try and use /bct if the ChatSender is in your group of bots, else it uses /tell
+	- check_Basics
+		>This is added for a check method you want to work across all toons, to limit the pollution of the Adv.ini 
 
-. Set up some type of fix for 'you can use the ability X again in Y minute(s) Z seconds
-	This should be easy enough to set up as event that creates a timer.
+	- PrivateCode.inc created and included for everyone. This is a place to include your personal customizations that you don't want to lose with future updates. 
+	***We will not provide future updates to this file. **NOTE** be sure to not overwrite your file with a future "BLANK" file***
+	***if you contribute to the github repository you can use this command to prevent git from uploading your private code ***
+	*** 	> git update-index --skip-worktree e3_PrivateCode.inc ****
+	
+--------- Pet Arming Changes:
+	- New Arm Pets feature which opens up new commands to the mage in your group.
+		> From the non-mage send a /tell to your mage
+		-> "arm pets", 
+		-> "arm pets fire" , 
+		-> "arm pets ice", 
+		-> "arm pets 2dispel", 
+		-> "arm pets default <character>", 
+		-> "arm pets ice <character>", 
+		-> "arm pets fire <character>" 
+		-> "arm pets 2dispel <character>"
+	
+	This will equip all the members of your group (if you don't specify character) with the spectral plate/heirlooms + configured loadouts for your class.
+	***NOTE*** a free bag space is required from your mage. 
 
-. Fix Auto-forage ( this is very very very...very minor )
-
-. Request- Add auto trade functions. Possibly auto accept trade with bots and a /bc notification when a non-bot is trading with a bot?
- 
-. Heal Chain.  I hate heal chains.
-
-. Drag Corpses.  This was taken out due to issues with server stability.
-
-. Add a function to cast a buff on a given bot
-
-. Create an event to allow users to search for settings, and change those settings on the fly
-	Something that would function much like the help file, but instead give you a read-out of different settings to toggle
-
-. add enhancements to /only and /not so that you can set your own "groups".  also make another tag for group leader only
-
-. rework auto assist.  This one sucks
-
-. raid invite stuff
-
-. group check function to tell you if groups are all formed correctly
-
-. Multiple inis
-
-. heals + / -
-
-
-| finish auto destroy stuff
-| Create toggles for various functions to be listed in either e3_Settings, or e3_Data.  These should be added to the set / toggle function list
-	/declare reagentCheckInterval int outer 60
-	/if (${Ini[${genSettings_Ini},Background,Reagent Check Interval (Min)].Length}) /varset reagentCheckInterval ${Ini[${genSettings_Ini},Background,Reagent Check Interval (Min)]}
-
+	- If you have any particular loadouts that you want to see, please let me know so I can include them. 
+		> Currently:
+		-> Mage/Enc/Nec default is Slow/Dispell.  SK/Druid default is Dispell/Mala, Everyone else is also Dispell/Mala. 
+		-> Mage/Enc/Nec fire is Fire/Fire, Sk/Druid is Fire/Mala
+		-> Mage/Enc/Nec ice is ice/ice, SK/Druid is ice/mala.
+		-> Mage/Enc/Nec 2dispel is dispel/dispel, SK/Druid is dispel/dispel.
 ===============================================================================================================================================================================================
 ===============================================================================================================================================================================================
 
@@ -60,6 +96,47 @@ v5.1 r8 Change log:
 	- e3 Data.ini no longer hardcodes a server name.
 	- Character INIs created while logged into Project Lazarus are now named "CharacterName_Lazarus" instead of "CharacterName_PEQTGC" (EX: Ewiclip_Lazarus.ini)
 		***NOTE: Project Lazarus players can continue to use INI files with PEQTGC in the name but new INIs are created with Lazarus in the name.***
+	- Project Lazarus "Gift of Mana" proc spells now work with the /GoM flag
+	
+--------- Added:
+
+	- New Loot Only Stackable Feature Added. Loot only stackable over N value. Optional flags for looting common or all trade skill items included, as well as the N value.
+	- TimeLeftOnMySpell(SpellName) function added -- returns seconds remaining for spells / items casted on the NPC by you. 
+	- GetEmptySpellGem function added -- returns an empty spell gem # if one exists
+	
+--------- Damage Over Time Changes:
+
+	- /AllowSpellSwap added : Allows DoTs to self-shuffle without getting stuck in a "mem -> demem -> mem" loop
+	- /TriggerSpell|SpellName added : Allows DoTs that put 2 Detrimental Effects on the NPC to recast if either the primary or secondary DoT is missing
+	- /NoEarlyRecast added : Allows you to define that a spell should NOT be recasted before it has worn off. (Think Splort/Splurt)
+	- /NoStack added : Allows you to skip this spell if anyone else has already casted it onto the NPC. (Most debuffs cannot be stacked from 2 people even if they have a DoT component)
+	- Damage Over Time spells now read the Target data instead of timer data for recasting.
+	- "QuickCast" feature added to allow items/AAs to cast immediately after spells without pausing for the universal cooldown. INIs need to define an item/AA immediately after a spell to take advantage of this.
+	- DoTs defined in the INI will automatically mem into open spell gems regardless of if the /Gem|# flag is passed or not.
+	
+===============================================================================================================================================================================================
+===============================================================================================================================================================================================
+
+v5.1 r7 Change log:
+
+--------- Fixed:
+
+	- Fixed issue with Magicians not summoning Mod Rods unless they had spell casting haste AAs.
+	- Fixed issue with e3_casting not properly  using items.
+	- Fixed issue with unpauseTwist not getting called in e3_Casting.
+	- Fixed issue with /Rotate trying to cast abilities/spells that were on cooldown already.
+	- Fixed memory leak caused by resist check timers not getting removed when a player switched targets.
+	
+--------- Changed:
+	
+	- Old mod rods get automatically deleted before Magicians summon new mod rods.
+	- Healers will now interrupt detrimental spells and HoTs to cast direct heals on Tank & XTarget as needed.
+	- AutoSetPctAAExp is now defaulted to OFF
+	- Damage Over Time casting has been completely overhauled. (details below)
+	- Nukes defined with a /GoM flag will no longer pause if that specific nuke is on cooldown
+	- e3_Cast can now be called with an additional parameter to silence the echo received from a successful cast. (EX: /call e3_Cast ${TargetID} ${ArrayName} ${i} 1)
+	- e3 Data.ini no longer hardcodes a server name.
+	- Character INIs created while logged into Project Lazarus are now named "CharacterName_Lazarus" instead of "CharacterName_PEQTGC" (EX: Ewiclip_Lazarus.ini)
 	- Project Lazarus "Gift of Mana" proc spells now work with the /GoM flag
 	
 --------- Added:

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1354,8 +1354,7 @@ SUB event_SwarmPets(line, ChatSender, int swarmTarget)
         /if (${c_Ready} && ${swarmPets2D[${i},${iIfs}]}) {
           /if (${check_Distance[${swarmTarget},${swarmPets2D[1,${iMyRange}]}]}) {
             /g SWARM-${swarmPets2D[${i},${iSpellName}]}
-				    /call e3_Cast ${swarmTarget} "swarmPets2D" "${i}"
-					  /delay 2s
+				    /call e3_Cast ${swarmTarget} "swarmPets2D" "${i}" 1
           }
         }
 			/next i
@@ -1750,18 +1749,24 @@ SUB assist_SpellArrays
 
   /if (${Me.Class.ShortName.Equal[MAG]}) {
 	/if (!${Defined[summonMoltenOrb]}) /declare summonMoltenOrb bool outer FALSE
-    /if (${Bool[${Me.AltAbility[Servant of Ro]}]})        /call BuildArray "swarmPets" "Servant of Ro"
-    /if (${Bool[${Me.AltAbility[Host of the Elements]}]}) /call BuildArray "swarmPets" "Host of the Elements"
-    /if (${Defined[MyNukes]}) {
-      /declare i int local
-      /for i 1 to ${MyNukes.Size}
-        /if (${MyNukes[${i}].Find[Lava Orb]}) /varset summonMoltenOrb TRUE
-      /next i
-    }
+  /if (${Bool[${Me.AltAbility[Servant of Ro]}]})        /call BuildArray "swarmPets" "Servant of Ro"
+  /if (${Bool[${Me.AltAbility[Host of the Elements]}]}) /call BuildArray "swarmPets" "Host of the Elements"
+
+  /if (${Defined[MyNukes]}) {
+    /declare i int local
+    /for i 1 to ${MyNukes.Size}
+      /if (${MyNukes[${i}].Find[Lava Orb]}) /varset summonMoltenOrb TRUE
+    /next i
+  }
+
   } else /if (${Me.Class.ShortName.Equal[NEC]}) {
     /if (${Bool[${Me.AltAbility[Swarm of Decay]}]}) /call BuildArray "swarmPets" "Swarm of Decay"
-    /if (${Bool[${Me.AltAbility[Wake the Dead]}]})  /call BuildArray "swarmPets" "Wake the Dead"
-	/if (${Bool[${Me.AltAbility[Wake the Dead]}]})  /call BuildArray "swarmPets" "Rise of Bones"
+	  /if (${Bool[${Me.AltAbility[Rise of Bones]}]})  /call BuildArray "swarmPets" "Rise of Bones"
+    /if (${Bool[${FindItem[Graverobber's Icon]}]}) /call BuildArray "swarmPets" "Graverobber's Icon"
+    /if (${Bool[${FindItem[Soulwhisper]}]}) /call BuildArray "swarmPets" "Soulwhisper"
+    /if (${Bool[${FindItem[Deathwhisper]}]}) /call BuildArray "swarmPets" "Deathwhisper"
+    |Ewiclip: Removing Wake The Dead -- It is known to cause zone crashing
+    |/if (${Bool[${Me.AltAbility[Wake the Dead]}]})  /call BuildArray "swarmPets" "Wake the Dead"
   } else /if (${Me.Class.ShortName.Equal[SHM]}) {
     /if (${Bool[${Me.AltAbility[Spirit Call]}]})    /call BuildArray "swarmPets" "Spirit Call"
     /if (${Bool[${FindItem[Shattered Gnoll Slayer]}]})    /call BuildArray "swarmPets" "Shattered Gnoll Slayer"
@@ -1771,6 +1776,7 @@ SUB assist_SpellArrays
     /if (${Bool[${Me.AltAbility[Song of Stone]}]})   /call BuildArray "swarmPets" "Song of Stone"
   } else /if (${Me.Class.ShortName.Equal[CLR]}) {
     /if (${Bool[${Me.AltAbility[Celestial Hammer]}]}) /call BuildArray "swarmPets" "Celestial Hammer"
+    /if (${Bool[${FindItem[Graverobber's Icon]}]}) /call BuildArray "swarmPets" "Graverobber's Icon"
   } else /if (${Me.Class.ShortName.Equal[ENC]}) {
     /if (${Bool[${Me.AltAbility[Doppelganger]}]}) {
       |/call BuildArray "swarmPets" "Doppelganger"

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -512,7 +512,7 @@ SUB check_Nukes
             /if (${c_Ready}) {
               /if (${Debug} || ${Debug_Assists}) /echo found a ready spell for GOM
               /varset castIndex ${m}
-              /bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
+              |/bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
               /varset lastSuccessfulCast 0
               /break
             } 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -387,20 +387,27 @@ SUB check_AutoAssist
 |- Casts direct damage spells on a specified target.	  -|
 |--------------------------------------------------------|
 SUB check_Nukes
+
 /if (${Debug} || ${Debug_Assists}) /echo |- check_Nukes ==>
 	/if (${Defined[Nukes2D]} && ${Assisting} && ${use_Nukes}) {
 	  /declare castIndex int local
 	  /declare s int local
     /declare m int local
     /declare assistToT int local
+    /declare typeOfCast string local 
     /declare HaveGiftOfManaBuff bool False local
     /if (${Bool[${Me.Song[Gift of Mana].ID}]} || ${Bool[${Me.Song[Celestial Gift].ID}]} || ${Bool[${Me.Song[Celestial Boon].ID}]}) {
         /varset HaveGiftOfManaBuff True
     }
 
    /for s 1 to ${Nukes2D.Size[1]}
+    
+    /varset typeOfCast  
+    
     /varset castIndex ${s}
     /if (${Debug} || ${Debug_Assists}) /echo ${s} ${castIndex} ${Nukes2D[${castIndex},${iCastName}]}
+
+    
 
     |allows use of druid/mage DS, etc, in nukes based on spellset. casts on assistTargets target
     /if (${Nukes2D[${castIndex},${iSpellType}].Find[Beneficial]}) {
@@ -419,10 +426,20 @@ SUB check_Nukes
         }
       }
     } else {
+
+      |When an item delay is applied to an entry, check to see if the delay is still active
+      |Check lower comment after the spell is cast for more information.
+      /if (${Defined[nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}]}) {
+        /if (${nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}}) {
+          |/bc check_nuke: skipping nukes as its timer isn't met yet:${Nukes2D[${castIndex},${iCastName}]} time left:${nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}}
+          /goto :skipCast
+        }
+      }
       | skip casting if a delay is defined and active
       /if (${Defined[castDelay${Nukes2D[${castIndex},${iCastID}]}]}) {
         /if (${castDelay${Nukes2D[${castIndex},${iCastID}]}}) {
-          /if (${Debug} || ${Debug_Assists}) /echo skipping nukes, /delay from previous cast
+          /if (${Debug} || ${Debug_Assists}) 
+          /echo skipping nukes, /delay from previous cast
           /return
         }
       }
@@ -439,7 +456,7 @@ SUB check_Nukes
       }
       | if /rotate is defined, and the current array index was the last successful cast, skip to next index
     /if (${Nukes2D[${castIndex},${iCastName}].Equal[${lastSuccessfulCast}]} && ${Nukes2D[${castIndex},${iRotate}]} && ${Nukes2D.Size[1]} > 1) {
-      /if (${Debug} || ${Debug_Assists}) /echo skipping cast of ${Nukes2D[${castIndex},${iCastName}]} /rotate is defined
+      /if (${Debug} || ${Debug_Assists}) /echo Possibly skipping cast of ${Nukes2D[${castIndex},${iCastName}]} /rotate is defined
       |need to check if any of our other spells can cast, if not, we can ignore this rotate
       /declare otherSpellsReady bool local
       /varset otherSpellsReady FALSE
@@ -449,29 +466,40 @@ SUB check_Nukes
       /for i 1 to ${Nukes2D.Size[1]}
         |if not the currently casting spell, lets check if they are ready to cast.          
         /if (!${Nukes2D[${i},${iCastName}].Equal[${currentCastName}]}) {
+          
           /call check_Ready "Nukes2D" ${i}
+          |When an item delay is applied to an entry, check to see if the delay is still active
+          |Check lower comment after the spell is cast for more information.
+          /if (${Defined[nukeSpellRecast_${Nukes2D[${i},${iSpellID}]}]}) {
+            /if (${nukeSpellRecast_${Nukes2D[${i},${iSpellID}]}}) {
+              /varset c_Ready FALSE
+            }
+          }
           /if (${c_Ready} && ${Nukes2D[${i},${iIfs}]}) {
-            /if (${Bool[${Nukes2D[${castIndex},${iGiftOfMana}]}]}) {
+            /if (${Bool[${Nukes2D[${i},${iGiftOfMana}]}]}) {
               |its specified to use gift of mana, well do we have it?
               /if (${HaveGiftOfManaBuff}) {
                 /varset otherSpellsReady TRUE
-                /if (${Debug} || ${Debug_Assists}) /echo other spells ready allowing the skip
+                /if (${Debug} || ${Debug_Assists}) /echo Another spell is defined as ready:${Nukes2D[${i},${iCastName}]}
                 /break
               }
             } else {
               /varset otherSpellsReady TRUE
-              /if (${Debug} || ${Debug_Assists}) /echo other spells ready allowing the skip
+              /if (${Debug} || ${Debug_Assists}) /echo Another spell is defined as ready:${Nukes2D[${i},${iCastName}]}
               /break
             }
           }
         }
       /next i
+   
+    
       |if others spells are ready to cast, its ok to skip this.
         /if (${otherSpellsReady}) {
-            /if (${Debug} || ${Debug_Assists}) /echo calling skipcast
+            |/if (${Debug} || ${Debug_Assists}) /echo another spell is ready to cast
+           
           /goto :skipCast
         } else {
-          /if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
+          |/if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
         }  
       }
 
@@ -480,11 +508,12 @@ SUB check_Nukes
         /if (${Debug} || ${Debug_Assists}) /echo have gift of mana, selecting GOM spell flag
         /for m 1 to ${Nukes2D.Size[1]}
           /if (${Nukes2D[${m},${iGiftOfMana}]}) {
-          
+        
             /call check_Ready "Nukes2D" ${m}
             /if (${c_Ready}) {
               /if (${Debug} || ${Debug_Assists}) /echo found a ready spell for GOM
               /varset castIndex ${m}
+              |/bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
               /varset lastSuccessfulCast 0
               /break
             } 
@@ -495,7 +524,6 @@ SUB check_Nukes
       /if (!${HaveGiftOfManaBuff} && ${Bool[${Nukes2D[${castIndex},${iGiftOfMana}]}]} ) {
           | we do not have gift of mana, make sure our current index is not a GOM spell, if so skip it
           /if (${Debug} || ${Debug_Assists}) /echo skipping gift of mana spell ${Nukes2D[${castIndex},${iCastName}]}
-          /varset lastSuccessfulCast 0
           /goto :skipcast
       }
 
@@ -546,9 +574,21 @@ SUB check_Nukes
                /varset Nukes2D[${castIndex},${iSubToRun}] check_HealCasting_DuringDetrimental
            
             }
+            /varset typeOfCast ${Nukes2D[${castIndex},${iCastType}]}
             /call e3_Cast ${AssistTarget} "Nukes2D" "${castIndex}"
           }
         }
+      }
+      
+
+      /if (${Select[${castReturn},CAST_SUCCESS]} && ${typeOfCast.Equal[Item]}) {
+          |when an item is click/cast, the server sends over the cooldown of said item
+          |so for a breif time between clicking there is an 'unkown' state where the items
+          |cooldown is still 0, even tho it isn't valid. Noticed this when using molten orbs.
+          |Adding a small delay to any item that is cast to prevent it from being a valid target
+          |on the next event cycle as event cycles in e3 are far faster than the server can send us
+          |the cooldown information
+          /call CreateTimer nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]} "1s"
       }
       |if the nuke was succesful, see if there is a delay defined and create a timer which locks out all nukes for the duration
       /if (${Bool[${Nukes2D[${castIndex},${iDelay}]}]} && ${Select[${castReturn},CAST_SUCCESS]}) {

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -438,8 +438,7 @@ SUB check_Nukes
       | skip casting if a delay is defined and active
       /if (${Defined[castDelay${Nukes2D[${castIndex},${iCastID}]}]}) {
         /if (${castDelay${Nukes2D[${castIndex},${iCastID}]}}) {
-          /if (${Debug} || ${Debug_Assists}) 
-          /echo skipping nukes, /delay from previous cast
+          /if (${Debug} || ${Debug_Assists}) /echo skipping nukes, /delay from previous cast
           /return
         }
       }
@@ -495,11 +494,11 @@ SUB check_Nukes
     
       |if others spells are ready to cast, its ok to skip this.
         /if (${otherSpellsReady}) {
-            |/if (${Debug} || ${Debug_Assists}) /echo another spell is ready to cast
+          /if (${Debug} || ${Debug_Assists}) /echo another spell is ready to cast
            
           /goto :skipCast
         } else {
-          |/if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
+          /if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
         }  
       }
 
@@ -513,7 +512,7 @@ SUB check_Nukes
             /if (${c_Ready}) {
               /if (${Debug} || ${Debug_Assists}) /echo found a ready spell for GOM
               /varset castIndex ${m}
-              |/bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
+              /bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
               /varset lastSuccessfulCast 0
               /break
             } 

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1600,7 +1600,8 @@ Sub basics_Background_Events
   /doevents collect
   /doevents sendInstanceInvites
   /doevents manastoneToggle
-  /doevent outOfSomething
+  /doevents outOfSomething
+  /doevents ItemDeleteSummoned
   /call check_StoneOn
 |		/varset event_counter 1
 |	} else {
@@ -1829,8 +1830,8 @@ sub event_gimme(line, ChatSender, RequestedItem)
       /delay 2s
       /bc Deleting old Mulation Shards, watch your cursor.
 			|get rid of old mod rods, to remote then local
-		  /bca //varset MethodCall_ItemDeleteSummoned ${RequestedItem}
-      /call check_ItemDeleteSummoned "${RequestedItem}"
+		  /bca ItemDeleteSummoned ${RequestedItem}
+      /call ItemDeleteSummoned "${RequestedItem}"
       /call ClearCursor
 		
     }
@@ -1877,7 +1878,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		| and flush the other events that have piled up as this is a long casting spell
 		/if (${IsRequestedItemModShard}) {
       /bc Putting new Mulation Shards in bags.
-     	/bca //varset MethodCall_ItemDeleteSummoned ClearCursor
+     	/bca ItemDeleteSummoned ClearCursor
       /call ClearCursor
 	    /doevents flush gimme
       /bc Done with Modulation shards
@@ -2095,8 +2096,8 @@ SUB check_Supply
             /bc A request for Modulation shards has been made, please pause for a moment. Starting in 4 seconds
             /delay 4s
             /bc Deleting old Mulation Shards, watch your cursor.
-            /bca //varset MethodCall_ItemDeleteSummoned ${supplyItem}
-            /call check_ItemDeleteSummoned "${supplyItem}"
+            /bca ItemDeleteSummoned ${supplyItem}
+            /call ItemDeleteSummoned "${supplyItem}"
             /delay 2s
 				}
 
@@ -2113,7 +2114,7 @@ SUB check_Supply
 				| If the item is a modulation shard, tell everyone to put it in their bag
 				/if (${supplyItem.Find[Modulation Shard]}) {
           	/bc Putting new Mulation Shards in bags.
-            /bca //varset MethodCall_ItemDeleteSummoned ClearCursor
+            /bca ItemDeleteSummoned ClearCursor
             /call ClearCursor
             |if people have bugged us for a shard as we deleted them all, flush out the event buffer
             /doevents flush gimme
@@ -2618,32 +2619,30 @@ SUB event_outOfSomething(line, Something)
 | Used in the summoning/deleting of mod shards. Doing this way to try and avoid
 | character disconnect to character creation.  Doing an itemnotify while casting
 | a spell will cause the toon to disconnect so we try and avoid that. 
-| We want this quasi-"event" to fire in the normal event loop of e3 so the toon 
+| We want this "event" to fire in the normal event loop of e3 so the toon 
 | is not doing anythin else. However we also want it to fire for only the non mage 
 | party members while the mage will call this manually while in mid macro.
-| *Note* I don't particuarlly like doing it this way and I am aware of events :P.
 |---------------------------------------------------------------------------------|
-SUB check_ItemDeleteSummoned(ItemString)
+#event ItemDeleteSummoned "<#1#> #2# ItemDeleteSummoned #3#"
+SUB event_ItemDeleteSummoned(line, ChatSender, MyName, ItemString)
 
-    /if (!${Defined[MethodCall_ItemDeleteSummoned]}) /declare MethodCall_ItemDeleteSummoned string outer "READY"
+  /call ItemDeleteSummoned "${ItemString}"
 
-    |check for a passed in varaible, if so , use it
-    /if (${ItemString.Length}>0) {
-        /varset MethodCall_ItemDeleteSummoned ${ItemString}
-    }
+/return
+SUB ItemDeleteSummoned(ItemString)
 
-    |has not been set, so nothing to do kick out
-    /if (${MethodCall_ItemDeleteSummoned.Equal[READY]}) /return
+  |didn't want to make ClearCusors its own event so shoved it in here for now.
+  /if (${ItemString.Find[ClearCursor]}) {
+        /call ClearCursor
+        /return
+  } 
 
-    /if (${MethodCall_ItemDeleteSummoned.Find[Summoned:]}) {
-        
-        /declare ItemToDelete string local ${MethodCall_ItemDeleteSummoned}
-        /varset MethodCall_ItemDeleteSummoned READY
-
-        /if (!${Bool[${FindItem[=${ItemToDelete}]}]}) {
+   /if (${ItemString.Find[Summoned:]}) {
+    
+        /if (!${Bool[${FindItem[=${ItemString}]}]}) {
             /return
         } 
-        /echo Trying to Deleting ${ItemToDelete}
+        /echo Trying to Deleting ${ItemString}
         /call ClearCursor
         /delay 1s
         |Found the issue of char disconnect. If you try and do a leftmouse up on an item and your casting
@@ -2651,17 +2650,11 @@ SUB check_ItemDeleteSummoned(ItemString)
         /while (${Cast.Status.Find[C]}) {
           /delay 1
         }
-        /itemnotify "${ItemToDelete}" leftmouseup
+        /itemnotify "${ItemString}" leftmouseup
         /delay 10s ${Bool[${Cursor.ID}]}
         /if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
 
-    } else /if (${MethodCall_ItemDeleteSummoned.Find[ClearCursor]}) {
-        /varset MethodCall_ItemDeleteSummoned READY
-        /call ClearCursor
-    } else {
-        /varset MethodCall_ItemDeleteSummoned READY
-    }
-
+    } 
 
 /RETURN
 |---------------------------------------------------------------------------------|
@@ -2670,8 +2663,5 @@ SUB check_ItemDeleteSummoned(ItemString)
 | utting methods that have complex checks will slow everything down
 |---------------------------------------------------------------------------------|
 Sub check_Basics
-
-  /call check_ItemDeleteSummoned ""
   /call check_ResistCounters
-
 /return

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1812,7 +1812,8 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		}
 	} else /if (${Bool[${FindItem[=Summoned: ${RequestedItem}]}]}) {
 		/ItemNotify "Summoned: ${RequestedItem}" leftmouseup
-		/delay 2s ${Bool[${Cursor.ID}]}
+		/delay 3s ${Bool[${Cursor.ID}]}
+    /delay 1s
 		
 	} else {
 	
@@ -1822,47 +1823,71 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/declare SummoningItem bool local true
 		/echo ${RequestedItem}
 		/if (${IsRequestedItemModShard}) {
+       /bc A request for Modulation shards has been made, please pause for a moment.
+       /delay 2s
+       /bc Deleting old Mulation Shards, watch your cursor.
 			|get rid of old mod rods, to remote then local
-			/bca //itemnotify "Summoned: Large Modulation Shard" leftmouseup
-			/itemnotify "Summoned: Large Modulation Shard" leftmouseup
+		  /bca //itemnotify "${RequestedItem}" leftmouseup
+			/itemnotify "${RequestedItem}" leftmouseup
 			/delay 2s
 			|be sure to evaluate this on the client side using noparse
-			/noparse /bca //if (${Cursor.Name.Find[Summoned:]}) /destroy
-			/if (${Cursor.Name.Find[Summoned:]}) /destroy
+			/noparse /bca //if (${Bool[${Cursor.ID}]} && ${Cursor.Name.Find[Summoned:]}) /destroy
+			/if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
 			/delay 2s
-			
+			/call ClearCursor
 		}
 		/if (${Bool[${Me.Book[${RequestedItem}]}]} || ${Bool[${Me.AltAbility[${RequestedItem}]}]}) {
+
 			/if (${DebugGimme}) /echo casting "${RequestedItem}"
-			/casting "${RequestedItem}"
-		} else /if (${Bool[${Me.Book[Summon: ${RequestedItem}]}]}) {
+			/call castSimpleSpell ${RequestedItem} ${Me.ID}
+     
+    } else /if (${Bool[${Me.Book[Summon: ${RequestedItem}]}]}) {
+
 			/if (${DebugGimme}) /echo casting "Summon: ${RequestedItem}"
-			/casting "Summon: ${RequestedItem}"
+      /call castSimpleSpell "Summon: ${RequestedItem}" ${Me.ID}
+		
 		} else /if (${Bool[${Me.Book[Summon ${RequestedItemStringWithoutSummoned}]}]}) {
-			/if (${DebugGimme}) /echo casting "Summon ${RequestedItemStringWithoutSummoned}"
-			/casting "Summon ${RequestedItemStringWithoutSummoned}"
-			/varset SummonSpellCast "Summon ${RequestedItemStringWithoutSummoned}"
-		} else /if (${Bool[${Me.Book[${RequestedItemStringWithoutSummoned}]}]} || ${Bool[${Me.AltAbility[${RequestedItemStringWithoutSummoned}]}]}) {
-			/if (${DebugGimme}) /echo casting ${RequestedItemStringWithoutSummoned}
-			/casting "${RequestedItemStringWithoutSummoned}"
-		} else /if (${Bool[${RequestedItem.Find[Sanguine Mind Crystal]}]} && ${Bool[${Me.AltAbility[Sanguine Mind Crystal]}]}) {
+		
+    	/if (${DebugGimme}) /echo casting "Summon ${RequestedItemStringWithoutSummoned}"
+      /call castSimpleSpell "Summon ${RequestedItemStringWithoutSummoned}" ${Me.ID}
+    	/varset SummonSpellCast "Summon ${RequestedItemStringWithoutSummoned}"
+		
+    } else /if (${Bool[${Me.Book[${RequestedItemStringWithoutSummoned}]}]} || ${Bool[${Me.AltAbility[${RequestedItemStringWithoutSummoned}]}]}) {
+		
+    	/if (${DebugGimme}) /echo casting ${RequestedItemStringWithoutSummoned}
+	    /call castSimpleSpell "${RequestedItemStringWithoutSummoned}" ${Me.ID}
+  
+  	} else /if (${Bool[${RequestedItem.Find[Sanguine Mind Crystal]}]} && ${Bool[${Me.AltAbility[Sanguine Mind Crystal]}]}) {
 			/if (${DebugGimme}) /echo casting Sanguine Mind Crystal
-			/casting "Sanguine Mind Crystal"
+
+      /call castSimpleSpell "Sanguine Mind Crystal" ${Me.ID}
+			
 		} else {
 			/delay 2s
 			/tell ${ChatSender} Spell ${RequestedItem} not found
 			/varset SummoningItem false
 		}
-		/if (${SummoningItem}) /delay 15s ${Bool[${Cursor.ID}]}
+		/if (${SummoningItem}) {
+        |we delay 1 sec after cusror id says it has something due to timing issues
+        /delay 15s ${Bool[${Cursor.ID}]}
+        /delay 1s
+
+    } 
 		/if (${DebugGimme}) /echo Summoned ${RequestedItem} ${SummoningItem}
 		
 		| If the item is a modulation shard, tell everyone to put it in their bag
 		| and flush the other events that have piled up as this is a long casting spell
 		/if (${IsRequestedItemModShard}) {
-			/bcaa //autoinventory
-			/doevents flush gimme
+      /bc Putting new Mulation Shards in bags.
+      /delay 1s
+			/bca //autoinventory
+      /call ClearCursor
+      /delay 2s
+      /doevents flush gimme
+      /bc Done with Modulation shards
 			/return
-		}
+		
+    }
 	}
 	
 	/if ((${Cursor.ID} || ${platOnCursor}) && !${IsRequestedItemModShard}) {
@@ -1883,10 +1908,9 @@ sub event_gimme(line, ChatSender, RequestedItem)
 			/delay 5
 			/bct ${Target.CleanName} //notify TradeWnd TRDW_Trade_Button leftmouseup 
 			/delay 1s
-			/varset tradeTries ${Math.Calc[${tradeTries} + 1]
-		}
+			/varset tradeTries ${Math.Calc[${tradeTries} + 1]}
       /echo tradeTries=${tradeTries}
-	}
+	  }
     /if (${Window[TradeWnd].Open}) {
       /echo Cancelling the trade with ${ChatSender}
       /t ${ChatSender} Cancelling the trade. Please turn on auto accept trades using /plugin mq2autoaccepttrades.
@@ -1903,6 +1927,24 @@ sub event_gimme(line, ChatSender, RequestedItem)
 	
 /return
 
+|--------------------------------------------------------------------------------------------|
+|- Used to call the e3_Cast for simple spells that cannot normally fail.                   	-|
+|--------------------------------------------------------------------------------------------|
+sub castSimpleSpell(spellName, simpleTargetID)
+
+  /if (${Defined[castSimpleSpellArray]}) /deletevar castSimpleSpellArray
+  /declare castSimpleSpellArray[1] string outer ${spellName}
+  /if (${castSimpleSpellArray.Size}) {
+    |/echo building the spell array for heirlooms
+    /call BuildSpellArray "castSimpleSpellArray" "castSimpleSpellArray2D"
+    /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
+    /while (!${Select[${castReturn},CAST_SUCCESS]}) {
+          /delay 1s
+          /call e3_Cast  ${simpleTargetID} "castSimpleSpellArray2D" 1 False
+    }
+    /if (${Defined[castSimpleSpellArray]}) /deletevar castSimpleSpellArray
+  }
+/return
 |----------------------------------------------------------------------------|
 |- Whenever nothing else is going on will check if the toon has all the items in the gimme list
 |- and request items it doesn't have from the target character
@@ -1996,14 +2038,27 @@ SUB check_Supply
   /if (${Waiting4Rez}) /return
   /if (${Bool[${Me.Buff[Resurrection Sickness]}]}) /return
 	/if (!${Defined[SupplyEnabled]}) /declare SupplyEnabled bool outer ${Bool[${Ini[${Character_Ini},Supply]}]}
-    /if (${SupplyEnabled} && !${Bool[${Cursor.ID}]} && !${medBreak} && !${Me.CombatState.Equal[DEBUFFED]} && !${Me.Invis} && ${Me.PctMana} == 100 && ${Me.PctHPs} == 100 && ${Me.PctAggro} < 1 && !${Me.CombatState.Equal[COMBAT]} && !${Assisting} && !${Me.Moving} && !${Me.Combat}) { 
-		/if (!${Defined[Supply]}) /call IniToArrayV "${Character_Ini},Supply,Supply#" Supply
+  
+  /if (!${SupplyEnabled}) /goto :endsupply
+  /if (${Bool[${Cursor.ID}]}) /goto :endsupply
+  /if (${Me.CombatState.Equal[DEBUFFED]}) /goto :endsupply
+  /if (${Me.CombatState.Equal[COMBAT]}) /goto :endsupply
+  /if (${Me.Invis}) /goto :endsupply
+  /if (${Me.Moving}) /goto :endsupply
+  /if (${Me.Combat}) /goto :endsupply
+  /if (${Assisting}) /goto :endsupply
+  /if (${Me.PctAggro} > 0) /goto :endsupply
+  
+  /if (${Me.PctMana} == 100 && ${Me.PctHPs} == 100 ) { 
+		
+    /if (!${Defined[Supply]}) /call IniToArrayV "${Character_Ini},Supply,Supply#" Supply
 		/declare i int local
 		/if (!${Defined[supplyItem]}) /declare supplyItem string local NULL
 		/if (!${Defined[supplySpell]}) /declare supplySpell string local NULL
 		/if (!${Defined[supplyTimeout]}) /declare supplyTimeout timer local NULL
 		/if (!${Defined[supplyGem]}) /declare supplyGem int local NULL
-		| Loop through the string, then loop through each of the items on that key	
+	
+    | Loop through the string, then loop through each of the items on that key	
 		/for i 1 to ${Supply.Size}
 			/varset supplyItem ${Supply[${i}].Arg[1,|]}
 			/varset supplySpell ${Supply[${i}].Arg[2,|]}
@@ -2017,20 +2072,39 @@ SUB check_Supply
 				/delay 1
 				/declare previousSpell string local ${Me.Gem[${supplyGem}]}
 				| If no spell gem specified, use default set in casting
+
+
+        | If the item is a modulation shard, tell the group to delete their old ones
+				/if (${supplyItem.Find[Modulation Shard]}) {
+            |get rid of old mod rods, to remote then local
+            /bc A request for Modulation shards has been made, please pause for a moment. Starting in 4 seconds
+            /delay 4s
+            /bc Deleting old Mulation Shards, watch your cursor.
+            /bca //itemnotify "${supplyItem}" leftmouseup
+            /delay 2s
+            |be sure to evaluate this on the client side using noparse
+            /noparse /bca //if (${Bool[${Cursor.ID}]} && ${Cursor.Name.Find[Summoned:]}) /destroy
+            /if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
+            /delay 2s
+				}
+
 				/if (${supplyGem} == 0 || ${supplyGem} == NULL) { 
-					/casting "${supplySpell}"
-				} else {
+           /call castSimpleSpell "${supplySpell}" ${Me.ID}
+       	} else {
 					/casting "${supplySpell}" ${supplyGem}
 				}
-				/delay 12s ${Cursor.ID}
-				/while (${Cursor.ID}) {
-					/autoinv
-					/delay 1s
-				}
+				/delay 20s ${Cursor.ID}
+        /call ClearCursor
+        /delay 1s
+  		  
 				| If the item is a modulation shard, tell everyone to put it in their bag
 				/if (${supplyItem.Find[Modulation Shard]}) {
-					/bcaa //autoinventory
-				}
+          	/bc Putting new Mulation Shards in bags.
+            /bca //autoinventory
+            |if people have bugged us for a shard as we deleted them all, flush out the event buffer
+            /doevents flush gimme
+            /bc Done with Modulation shards
+      	}
 				| Memorize the previous spell if needed
 				/if (${Bool[${previousSpell}]}) {
 					/delay 1s
@@ -2042,6 +2116,7 @@ SUB check_Supply
 			}
 		/next i
 	}
+  :endsupply
 	/if (${Debug}) /echo <== check_Supply -|
 /RETURN
 

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -301,6 +301,13 @@ SUB EVENT_clickIt(line, ChatSender, eventParams)
     :retryClickDoor
     /delay ${clickDelay}
     /squelch /doortarget id ${closestDoorID}
+    
+    |casting while zoning has been reported to cause a problem
+    | If casting, dismount if mounted and call /stopcast
+    /if (${Cast.Status.Find[C]}) {
+      /if (${NetBots[${Me.Name}].Mounted}) /dismount
+      /stopcast
+    }
     /squelch /click left door
     /if (${MyZone}==${Zone.ID} && ${Math.Distance[${startingLoc}]} < 10) {
       /if (${clickTimer}) {

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1829,9 +1829,8 @@ sub event_gimme(line, ChatSender, RequestedItem)
       /delay 2s
       /bc Deleting old Mulation Shards, watch your cursor.
 			|get rid of old mod rods, to remote then local
-		  /bca //varset ItemDeleteSummoned ${RequestedItem}
-      /varset ItemDeleteSummoned ${RequestedItem}
-      /call check_ItemDeleteSummoned
+		  /bca //varset MethodCall_ItemDeleteSummoned ${RequestedItem}
+      /call check_ItemDeleteSummoned "${RequestedItem}"
       /call ClearCursor
 		
     }
@@ -1878,7 +1877,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		| and flush the other events that have piled up as this is a long casting spell
 		/if (${IsRequestedItemModShard}) {
       /bc Putting new Mulation Shards in bags.
-     	/bca //varset ItemDeleteSummoned ClearCursor
+     	/bca //varset MethodCall_ItemDeleteSummoned ClearCursor
       /call ClearCursor
 	    /doevents flush gimme
       /bc Done with Modulation shards
@@ -2096,9 +2095,8 @@ SUB check_Supply
             /bc A request for Modulation shards has been made, please pause for a moment. Starting in 4 seconds
             /delay 4s
             /bc Deleting old Mulation Shards, watch your cursor.
-            /bca //varset ItemDeleteSummoned ${supplyItem}
-            /varset ItemDeleteSummoned ${supplyItem}
-            /call check_ItemDeleteSummoned
+            /bca //varset MethodCall_ItemDeleteSummoned ${supplyItem}
+            /call check_ItemDeleteSummoned "${supplyItem}"
             /delay 2s
 				}
 
@@ -2115,7 +2113,7 @@ SUB check_Supply
 				| If the item is a modulation shard, tell everyone to put it in their bag
 				/if (${supplyItem.Find[Modulation Shard]}) {
           	/bc Putting new Mulation Shards in bags.
-            /bca //varset ItemDeleteSummoned ClearCursor
+            /bca //varset MethodCall_ItemDeleteSummoned ClearCursor
             /call ClearCursor
             |if people have bugged us for a shard as we deleted them all, flush out the event buffer
             /doevents flush gimme
@@ -2616,21 +2614,31 @@ SUB event_outOfSomething(line, Something)
   /docommand ${ChatToggle} [${Me.Name}] I'm out of ${Something}!
 /return
 
-|----------------------------------------------------------------------------|
-| Used in the summoning/deleting of mod rods. Doing this way to try and avoid
-| character disconnect to character creation. ATM leading theory is 
-| doing things with raw /bca commands to autoinventory/destroy is causing it. 
-| This way we set the events of destroy/etc in the main e3 event loop so not 
-| doing out of bound things
-|----------------------------------------------------------------------------|
-SUB check_ItemDeleteSummoned
+|--------------------------------------------------------------------------------|
+| Used in the summoning/deleting of mod shards. Doing this way to try and avoid
+| character disconnect to character creation.  Doing an itemnotify while casting
+| a spell will cause the toon to disconnect so we try and avoid that. 
+| We want this quasi-"event" to fire in the normal event loop of e3 so the toon 
+| is not doing anythin else. However we also want it to fire for only the non mage 
+| party members while the mage will call this manually while in mid macro.
+| *Note* I don't particuarlly like doing it this way and I am aware of events :P.
+|---------------------------------------------------------------------------------|
+SUB check_ItemDeleteSummoned(ItemString)
 
-    /if (!${Defined[ItemDeleteSummoned]}) /declare ItemDeleteSummoned string outer "READY"
+    /if (!${Defined[MethodCall_ItemDeleteSummoned]}) /declare MethodCall_ItemDeleteSummoned string outer "READY"
 
-    /if (!${ItemDeleteSummoned.Equal[READY]} && ${ItemDeleteSummoned.Find[Summoned:]}) {
+    |check for a passed in varaible, if so , use it
+    /if (${ItemString.Length}>0) {
+        /varset MethodCall_ItemDeleteSummoned ${ItemString}
+    }
+
+    |has not been set, so nothing to do kick out
+    /if (${MethodCall_ItemDeleteSummoned.Equal[READY]}) /return
+
+    /if (${MethodCall_ItemDeleteSummoned.Find[Summoned:]}) {
         
-        /declare ItemToDelete string local ${ItemDeleteSummoned}
-        /varset ItemDeleteSummoned READY
+        /declare ItemToDelete string local ${MethodCall_ItemDeleteSummoned}
+        /varset MethodCall_ItemDeleteSummoned READY
 
         /if (!${Bool[${FindItem[=${ItemToDelete}]}]}) {
             /return
@@ -2639,20 +2647,31 @@ SUB check_ItemDeleteSummoned
         /call ClearCursor
         /delay 1s
         |Found the issue of char disconnect. If you try and do a leftmouse up on an item and your casting
-        |the server will disconnect you.
+        |the server will disconnect you. So doing this out of bound of E3's event loop is dangerous
         /while (${Cast.Status.Find[C]}) {
           /delay 1
         }
         /itemnotify "${ItemToDelete}" leftmouseup
         /delay 10s ${Bool[${Cursor.ID}]}
         /if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
-        
-       
-    } else /if (!${ItemDeleteSummoned.Equal[READY]} && ${ItemDeleteSummoned.Find[ClearCursor]}) {
 
-        /varset ItemDeleteSummoned READY
+    } else /if (${MethodCall_ItemDeleteSummoned.Find[ClearCursor]}) {
+        /varset MethodCall_ItemDeleteSummoned READY
         /call ClearCursor
-        
+    } else {
+        /varset MethodCall_ItemDeleteSummoned READY
     }
 
+
 /RETURN
+|---------------------------------------------------------------------------------|
+| Centralized area to call methods that will be called every event loop
+| Warning only put things that check very quickly if they should be called or not.
+| utting methods that have complex checks will slow everything down
+|---------------------------------------------------------------------------------|
+Sub check_Basics
+
+  /call check_ItemDeleteSummoned ""
+  /call check_ResistCounters
+
+/return

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2638,6 +2638,11 @@ SUB check_ItemDeleteSummoned
         /echo Trying to Deleting ${ItemToDelete}
         /call ClearCursor
         /delay 1s
+        |Found the issue of char disconnect. If you try and do a leftmouse up on an item and your casting
+        |the server will disconnect you.
+        /while (${Cast.Status.Find[C]}) {
+          /delay 1
+        }
         /itemnotify "${ItemToDelete}" leftmouseup
         /delay 10s ${Bool[${Cursor.ID}]}
         /if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1952,13 +1952,18 @@ sub notifyViaBCTell(targetToTell, messageToSend)
 |--------------------------------------------------------------------------------------------|
 |- Used to call the e3_Cast for simple spells that cannot normally fail.                   	-|
 |--------------------------------------------------------------------------------------------|
-sub castSimpleSpell(spellName, simpleTargetID)
+sub castSimpleSpell(spellNameToBase, simpleTargetIDToBase)
+
+    /call castSimpleSpellBase "${spellNameToBase}" ${simpleTargetIDToBase} True
+
+/return
+sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
 
   /if (${Defined[castSimpleSpellArray]}) /deletevar castSimpleSpellArray
-  /declare castSimpleSpellArray[1] string outer "${spellName}"
+  /declare castSimpleSpellArray[1] string outer ${spellName}
   /if (${castSimpleSpellArray.Size}) {
     |/echo building the spell array for heirlooms
-    /call BuildSpellArray "castSimpleSpellArray" "castSimpleSpellArray2D"
+    /call BuildSpellArrayBase "castSimpleSpellArray" "castSimpleSpellArray2D" ${SkipParams}
    
     /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
     /while (${Select[${castReturn},CAST_FIZZLE]}) {
@@ -2112,7 +2117,9 @@ SUB check_Supply
            /echo Supply trying to get a:"${supplySpell}" 
            /call castSimpleSpell "${supplySpell}" ${Me.ID}
        	} else {
-					/casting "${supplySpell}" ${supplyGem}
+           /echo Supply with Gem specific: ${supplySpell}/Gem|${supplyGem}
+           /call castSimpleSpellBase "${supplySpell}/Gem|${supplyGem}" ${Me.ID} False
+					 |/casting "${supplySpell}" ${supplyGem}
 				}
 				/delay 20s ${Cursor.ID}
         /call ClearCursor

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2569,53 +2569,6 @@ SUB check_Forage
 /if (${Debug}) /echo <== check_Forage -|
 /RETURN
 
-|----------------------------------------------------------------------------|
-|- Sends instance invites to all those in your group or raid.
-|- Install Instructions:
-|-     Add this SUB to the bottom of e3 Includes/e3_Basics.inc
-|-     Add /doevents sendInstanceInvites to SUB basics_Background_Events
-|- Usage Instructions:
-|-     Use "/bc inst invite" on the toon in the instance
-|-     to send out instance invites.
-|----------------------------------------------------------------------------|
-#event sendInstanceInvites "<#1#> inst invite"
-SUB event_sendInstanceInvites(line, ChatSender)
-	/if (!${Me.Name.Equal[${ChatSender}]}) /return
-
-	/if (!${Me.InInstance}) {
-		/echo You are not in an instance.
-		/return
-	}
-	
-	/declare membersStr string local
-	
-	/if (${Raid.Members} == 0 && ${Group.Members} == 0) {
-		/echo You are not in a group or raid. Therefore, there is no one to invite.
-	} else /if (${Raid.Members} == 0 && ${Group.Members} > 0) {
-		/declare i int local
-		/for i 1 to ${Group.Members} {
-			/if (${Group.Member[${i}].Name.NotEqual[${ChatSender}]}) /varset membersStr ${membersStr} ${Group.Member[${i}].Name}
-		}
-		/next i
-	} else /if (${Raid.Members} > 0) {
-		/declare i int local
-		/for i 1 to ${Raid.Members} {
-			/if (${Raid.Member[${i}].Name.NotEqual[${ChatSender}]}) /varset membersStr ${membersStr} ${Raid.Member[${i}].Name}
-		}
-		/next i
-	} else {
-		/echo Unable to send instance invites to your group/raid members.
-		/return
-	}
-	
-	/if (${membersStr.Length} > 0) {
-		/echo Sending instance invites!
-		/say #inst invite ${membersStr}
-	} else {
-		/echo There are no group/raid members to send invites to.
-	}
-/return
-
 |** Warn you when a bot is out of food/drink **|
 #event outOfSomething "You are out of #1#."
 SUB event_outOfSomething(line, Something)

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2660,7 +2660,7 @@ SUB ItemDeleteSummoned(ItemString)
 |---------------------------------------------------------------------------------|
 | Centralized area to call methods that will be called every event loop
 | Warning only put things that check very quickly if they should be called or not.
-| utting methods that have complex checks will slow everything down
+| putting methods that have complex checks will slow everything down
 |---------------------------------------------------------------------------------|
 Sub check_Basics
   /call check_ResistCounters

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1825,19 +1825,16 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/declare SummoningItem bool local true
 		/echo ${RequestedItem}
 		/if (${IsRequestedItemModShard}) {
-       /bc A request for Modulation shards has been made, please pause for a moment.
-       /delay 2s
-       /bc Deleting old Mulation Shards, watch your cursor.
+      /bc A request for Modulation shards has been made, please pause for a moment.
+      /delay 2s
+      /bc Deleting old Mulation Shards, watch your cursor.
 			|get rid of old mod rods, to remote then local
-		  /bca //itemnotify "${RequestedItem}" leftmouseup
-			/itemnotify "${RequestedItem}" leftmouseup
-			/delay 2s
-			|be sure to evaluate this on the client side using noparse
-			/noparse /bca //if (${Bool[${Cursor.ID}]} && ${Cursor.Name.Find[Summoned:]}) /destroy
-			/if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
-			/delay 2s
-			/call ClearCursor
-		}
+		  /bca //varset ItemDeleteSummoned ${RequestedItem}
+      /varset ItemDeleteSummoned ${RequestedItem}
+      /call check_ItemDeleteSummoned
+      /call ClearCursor
+		
+    }
 		/if (${Bool[${Me.Book[${RequestedItem}]}]} || ${Bool[${Me.AltAbility[${RequestedItem}]}]}) {
 
 			/if (${DebugGimme}) /echo casting "${RequestedItem}"
@@ -1881,11 +1878,9 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		| and flush the other events that have piled up as this is a long casting spell
 		/if (${IsRequestedItemModShard}) {
       /bc Putting new Mulation Shards in bags.
-      /delay 1s
-			/bca //autoinventory
+     	/bca //varset ItemDeleteSummoned ClearCursor
       /call ClearCursor
-      /delay 2s
-      /doevents flush gimme
+	    /doevents flush gimme
       /bc Done with Modulation shards
 			/return
 		
@@ -1959,7 +1954,7 @@ sub castSimpleSpell(spellName, simpleTargetID)
     /call BuildSpellArray "castSimpleSpellArray" "castSimpleSpellArray2D"
    
     /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
-    /while (!${Select[${castReturn},CAST_SUCCESS]}) {
+    /while (${Select[${castReturn},CAST_FIZZLE]}) {
           /delay 1s
           /call e3_Cast  ${simpleTargetID} "castSimpleSpellArray2D" 1 False
     }
@@ -2101,11 +2096,9 @@ SUB check_Supply
             /bc A request for Modulation shards has been made, please pause for a moment. Starting in 4 seconds
             /delay 4s
             /bc Deleting old Mulation Shards, watch your cursor.
-            /bca //itemnotify "${supplyItem}" leftmouseup
-            /delay 2s
-            |be sure to evaluate this on the client side using noparse
-            /noparse /bca //if (${Bool[${Cursor.ID}]} && ${Cursor.Name.Find[Summoned:]}) /destroy
-            /if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
+            /bca //varset ItemDeleteSummoned ${supplyItem}
+            /varset ItemDeleteSummoned ${supplyItem}
+            /call check_ItemDeleteSummoned
             /delay 2s
 				}
 
@@ -2122,7 +2115,8 @@ SUB check_Supply
 				| If the item is a modulation shard, tell everyone to put it in their bag
 				/if (${supplyItem.Find[Modulation Shard]}) {
           	/bc Putting new Mulation Shards in bags.
-            /bca //autoinventory
+            /bca //varset ItemDeleteSummoned ClearCursor
+            /call ClearCursor
             |if people have bugged us for a shard as we deleted them all, flush out the event buffer
             /doevents flush gimme
             /bc Done with Modulation shards
@@ -2621,3 +2615,39 @@ SUB event_sendInstanceInvites(line, ChatSender)
 SUB event_outOfSomething(line, Something)
   /docommand ${ChatToggle} [${Me.Name}] I'm out of ${Something}!
 /return
+
+|----------------------------------------------------------------------------|
+| Used in the summoning/deleting of mod rods. Doing this way to try and avoid
+| character disconnect to character creation. ATM leading theory is 
+| doing things with raw /bca commands to autoinventory/destroy is causing it. 
+| This way we set the events of destroy/etc in the main e3 event loop so not 
+| doing out of bound things
+|----------------------------------------------------------------------------|
+SUB check_ItemDeleteSummoned
+
+    /if (!${Defined[ItemDeleteSummoned]}) /declare ItemDeleteSummoned string outer "READY"
+
+    /if (!${ItemDeleteSummoned.Equal[READY]} && ${ItemDeleteSummoned.Find[Summoned:]}) {
+        
+        /declare ItemToDelete string local ${ItemDeleteSummoned}
+        /varset ItemDeleteSummoned READY
+
+        /if (!${Bool[${FindItem[=${ItemToDelete}]}]}) {
+            /return
+        } 
+        /echo Trying to Deleting ${ItemToDelete}
+        /call ClearCursor
+        /delay 1s
+        /itemnotify "${ItemToDelete}" leftmouseup
+        /delay 10s ${Bool[${Cursor.ID}]}
+        /if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
+        
+       
+    } else /if (!${ItemDeleteSummoned.Equal[READY]} && ${ItemDeleteSummoned.Find[ClearCursor]}) {
+
+        /varset ItemDeleteSummoned READY
+        /call ClearCursor
+        
+    }
+
+/RETURN

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1839,7 +1839,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/if (${Bool[${Me.Book[${RequestedItem}]}]} || ${Bool[${Me.AltAbility[${RequestedItem}]}]}) {
 
 			/if (${DebugGimme}) /echo casting "${RequestedItem}"
-			/call castSimpleSpell ${RequestedItem} ${Me.ID}
+			/call castSimpleSpell "${RequestedItem}" ${Me.ID}
      
     } else /if (${Bool[${Me.Book[Summon: ${RequestedItem}]}]}) {
 
@@ -1891,7 +1891,9 @@ sub event_gimme(line, ChatSender, RequestedItem)
 	}
 	
 	/if ((${Cursor.ID} || ${platOnCursor}) && !${IsRequestedItemModShard}) {
-		/declare originalLoc string local ${Me.Loc}
+		/target pc ${ChatSender}
+    /delay 1s
+    /declare originalLoc string local ${Me.Loc}
 		/if (${DebugGimme}) /echo IsClose = ${Bool[${Math.Distance[${senderLoc}]}<20]}
 		/stick 12
 		/while (${Math.Distance[${Spawn[${ChatSender}].Loc}]}>20) {
@@ -1933,10 +1935,11 @@ sub event_gimme(line, ChatSender, RequestedItem)
 sub castSimpleSpell(spellName, simpleTargetID)
 
   /if (${Defined[castSimpleSpellArray]}) /deletevar castSimpleSpellArray
-  /declare castSimpleSpellArray[1] string outer ${spellName}
+  /declare castSimpleSpellArray[1] string outer "${spellName}"
   /if (${castSimpleSpellArray.Size}) {
     |/echo building the spell array for heirlooms
     /call BuildSpellArray "castSimpleSpellArray" "castSimpleSpellArray2D"
+   
     /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
     /while (!${Select[${castReturn},CAST_SUCCESS]}) {
           /delay 1s
@@ -2089,6 +2092,7 @@ SUB check_Supply
 				}
 
 				/if (${supplyGem} == 0 || ${supplyGem} == NULL) { 
+           /echo Supply trying to get a:"${supplySpell}" 
            /call castSimpleSpell "${supplySpell}" ${Me.ID}
        	} else {
 					/casting "${supplySpell}" ${supplyGem}

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1891,8 +1891,11 @@ sub event_gimme(line, ChatSender, RequestedItem)
 	}
 	
 	/if ((${Cursor.ID} || ${platOnCursor}) && !${IsRequestedItemModShard}) {
-		/target pc ${ChatSender}
-    /delay 1s
+		
+    /Echo Gimmie: Getting target of requester
+    /target pc ${ChatSender}
+    /delay 10s ${Target.ID}==${Spawn[${ChatSender}].ID}
+
     /declare originalLoc string local ${Me.Loc}
 		/if (${DebugGimme}) /echo IsClose = ${Bool[${Math.Distance[${senderLoc}]}<20]}
 		/stick 12

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -304,7 +304,7 @@ SUB EVENT_clickIt(line, ChatSender, eventParams)
     
     |casting while zoning has been reported to cause a problem
     | If casting, dismount if mounted and call /stopcast
-    /if (${Cast.Status.Find[C]}) {
+    /if (${Cast.Status.Find[C]} || ${Me.Casting.ID}) {
       /if (${NetBots[${Me.Name}].Mounted}) /dismount
       /stopcast
     }

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1708,9 +1708,11 @@ Sub basics_Aliases
 |- Must add /doevents gimme to basics_Background_Events in e3_Basics.ini
 |-----------------------------------------------------------|
 #event gimme "#1# tells you, 'Gimme #2#'"
-|#event gimme "<#1#> Gimme #2#"
+#event gimme "<#1#> Gimme #2#"
+#event gimme "[#1#(msg)] Gimme #2#"
 sub event_gimme(line, ChatSender, RequestedItem)
-	/declare DebugGimme false
+
+  /declare DebugGimme false
 	/declare SummonSpellCast 
 	/if (${DebugGimme}) /echo |- event_gimme ==>
   /if (${Waiting4Rez}) /return
@@ -1720,12 +1722,12 @@ sub event_gimme(line, ChatSender, RequestedItem)
 	/if (${DebugGimme}) /echo ${senderLoc}
 	/if (${DebugGimme}) /echo Distance = ${Math.Distance[${senderLoc}]}
 	/if (${Math.Distance[${Spawn[${ChatSender}].Loc}]}>100) {
-		/tell ${ChatSender} You're too far away. Please move closer and ask again.
-		/return
+		/call notifyViaBCTell  ${ChatSender} "You're too far away. Please move closer and ask again."
+   	/return
 	}
 	/if (${Bool[${Cursor.ID}]} || ${medBreak} || ${Me.Invis} || ${Me.PctHPs} < 85 || ${Me.PctAggro} > 1 || ${Me.CombatState.Equal[COMBAT]} || ${Assisting} || ${Me.Moving} || ${Me.Combat}) {
-		/tell ${ChatSender} I'm busy
-		/return
+    /call notifyViaBCTell  ${ChatSender} "I'm busy"
+  	/return
 	}
 	/declare platOnCursor local false
 	/target pc ${ChatSender}
@@ -1740,13 +1742,13 @@ sub event_gimme(line, ChatSender, RequestedItem)
   }
 
   /if (!${GimmeSharing} && !${IsMyBot}) {
-    /tell ${ChatSender} I have disabled Gimme sharing, please seek your supplies elsewhere
+    /call notifyViaBCTell  ${ChatSender} "I have disabled Gimme sharing, please seek your supplies elsewhere"
     /return
   }
 
 	| check if the requestor can be reached
 	/if (!${Spawn[${ChatSender}].LineOfSight}) {
-		/tell ${ChatSender} Where are you? I don't see you. Please move closer if you want me to give you something.
+		/call notifyViaBCTell  ${ChatSender} "Where are you? I don't see you. Please move closer if you want me to give you something."
 		/delay 10
 		/return
 	}	
@@ -1754,7 +1756,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 	/if (${DebugGimme}) /echo RequestedItem IsModShard = ${Bool[${RequestedItem.Find[Modulation Shard]}]}
 	/declare IsRequestedItemModShard bool local ${Bool[${RequestedItem.Find[Modulation Shard]}]}
 	
-	/tell ${ChatSender} ${RequestedItem}, coming right up
+	/call notifyViaBCTell  ${ChatSender} "${RequestedItem}, coming right up"
 	/declare DiamondCoinName Diamond Coin
 	/declare DCName DC
 	/declare DiamondCoinsName Diamond Coins
@@ -1795,7 +1797,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 			/varset platOnCursor true
 		} else {
 			/delay 3s
-			/tell ${ChatSender} I'm all out of ${RequestedItem}
+			/call notifyViaBCTell  ${ChatSender} "I'm all out of ${RequestedItem}"
 		}
 	} else /if (${Bool[${FindItem[=${RequestedItem}]}]} && !${IsRequestedItemModShard}) {
 		/if (${DebugGimme}) /echo Found item ${RequestedItem}
@@ -1864,7 +1866,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 			
 		} else {
 			/delay 2s
-			/tell ${ChatSender} Spell ${RequestedItem} not found
+			/call notifyViaBCTell  ${ChatSender} "Spell ${RequestedItem} not found"
 			/varset SummoningItem false
 		}
 		/if (${SummoningItem}) {
@@ -1926,12 +1928,25 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/if (${Stick.Active}) /squelch /stick off
 		/if (${Math.Distance[${originalLoc}]}>20) /call MoveToLoc ${originalLoc} 50 20
 	} else /if (!${IsRequestedItemModShard}) {
-		/tell ${ChatSender} Sorry, I don't have a ${RequestedItem} and couldn't summon one for you. The spell/AA may be on cooldown.
+		/call notifyViaBCTell  ${ChatSender} "Sorry, I don't have a ${RequestedItem} and couldn't summon one for you. The spell/AA may be on cooldown."
 	} 
 	
 	
 /return
+sub notifyViaBCTell(targetToTell, messageToSend)
+  /declare IsTargetMyBot bool local False
+	/varset IsTargetMyBot ${Bool[${Select[${targetToTell}, ${NetBots.Client}]}]}		
 
+   /if (${IsTargetMyBot}) {
+
+      /bct ${targetToTell} ${messageToSend}
+
+    } else {
+  
+      /tell ${targetToTell} ${messageToSend}
+    }
+
+/return
 |--------------------------------------------------------------------------------------------|
 |- Used to call the e3_Cast for simple spells that cannot normally fail.                   	-|
 |--------------------------------------------------------------------------------------------|
@@ -2006,7 +2021,7 @@ SUB check_Gimme
 					/if (${Bool[${Spawn[pc ${gimmeCharacter}]}]}) {
 						/echo ==> Gimme: Hey ${gimmeCharacter} Gimme a ${gimmeItem}
 						/delay 1
-						/tell ${Gimmies[${i}].Arg[1,|]} Gimme ${gimmeItem}
+            /call notifyViaBCTell ${gimmeCharacter} "Gimme ${gimmeItem}"
 					}
 					/varset GimmeTimer${i} ${gimmeTimeout}
 					| Minimum of 10s delay between requests

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -139,7 +139,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |  Casting
 :cast_spell
   |/if (${Me.Name.Equal[Lube]}) /gu Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
-	/if (!${StopEchos}) /echo Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
+	/if (!${StopEchos}) /echo Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID} in ${e3CastTime}
 	|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|Use Disc
 	/if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]}) {
@@ -153,7 +153,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/squelch /target id ${targetID}
 				/delay 5 ${Target.ID} == ${targetID}
 			}
-      /varset ActionTaken TRUE
+			/varset ActionTaken TRUE
 			/disc ${pendingCast}
 		}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -197,12 +197,19 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		}
     |/echo AT pendingCastID ${pendingCastID} pendingType ${pendingType}" "-targetid|${targetID}"
 	/varset ActionTaken TRUE
+	
+
     /if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
 		/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+
 			/useitem "${pendingCast}"
-			/delay 3
 			|set to a default good value unless overwritten for a reason
 			/varset castReturn CAST_SUCCESS
+			|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
+			|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
+			|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
+			/delay 3
+			
 
 		} else {
 			/casting "${pendingCastID}|${pendingType}"		
@@ -222,9 +229,14 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			/next i_target
 			|/echo casting item "${pendingCast}" on ${targetID}
 			/useitem "${pendingCast}"
-			/delay 3
 			|set to a default good value unless overwritten for a reason
 			/varset castReturn CAST_SUCCESS
+			|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
+			|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
+			|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
+			/delay 3
+			|set to a default good value unless overwritten for a reason
+			
 		} else {
 			/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
 		}
@@ -352,6 +364,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
   /if (${Me.Class.ShortName.Equal[BRD]}) /varset resumeTwistDelay 5
   /if (${returnTwist})	/call unpauseTwist
 	/if (${Debug} || ${Debug_Casting})  /echo |- e3_Cast -| castReturn= ${Cast.Result} ${castReturn}
+
 |/varset Debug_Casting FALSE
 /return
 

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -126,21 +126,21 @@ sub event_armPets(line, ChatSender, loadType)
     
     /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && ${Spawn[${Group.Member[${counter}]}].Pet.Level}>1) {
       
-      /echo Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
-       /if (${Me.Book[Grant Enibik's Heirlooms]}) {
+      /bc Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
+      /if (${Me.Book[Grant Enibik's Heirlooms]}) {
+           /bc Arm Pets: Creating Heirlooms
            /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
       } 
       /if (${Cursor.ID}) {
-        /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
+        /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
         /goto :armpetend
       }
       /if (${Me.Book[Grant Spectral Plate]}) {
+        /bc Arm Pets: Creating Spectral Plate
         /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
       }
       /if (${Cursor.ID}) {
-        /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
+        /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
         /goto :armpetend
       }
       
@@ -228,12 +228,12 @@ sub event_armPets(line, ChatSender, loadType)
 
         }
 
-        /echo Selected Weapons are ${primaryWeapon} and ${secondaryWeapon}
+        /bc Arm Pets: Selected Weapons are ${primaryWeapon} and ${secondaryWeapon}
+        /bc Arm Pets: Creating Weapons
         /call summonUnpackAndSelect ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Armaments" "Folded Pack of Spectral Armaments" ${primaryWeapon} ${secondaryWeapon}
       }
       /if (${Cursor.ID}) {
-        /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
+        /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
         /goto :armpetend
       }
 
@@ -249,8 +249,7 @@ sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryI
       /if (${Defined[armPetArray]}) /deletevar armPetArray
       /declare armPetArray[1] string outer ${spellName}
       /if (${armPetArray.Size}) {
-        |/echo building the spell array for heirlooms
-
+      
         /call BuildSpellArray "armPetArray" "armPetArray2D"
         /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
         /while (!${Select[${castReturn},CAST_SUCCESS]}) {

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -97,6 +97,7 @@ sub event_armPets(line, ChatSender, loadType)
     /tell ${ChatSender}  Arm Pets: No empty bag slot on mage. Exiting.
     /goto :armpetend
   } 
+ 
 
   /tell ${ChatSender} Starting the arming of group pets.
   |note for the weapons, you need na empty bag slot for this to work.
@@ -126,106 +127,110 @@ sub event_armPets(line, ChatSender, loadType)
     /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && ${Spawn[${Group.Member[${counter}]}].Pet.Level}>1) {
       
       /echo Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
- 
-      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
+       /if (${Me.Book[Grant Enibik's Heirlooms]}) {
+           /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
+      } 
       /if (${Cursor.ID}) {
         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
         /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
         /goto :armpetend
       }
-      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
+      /if (${Me.Book[Grant Spectral Plate]}) {
+        /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
+      }
       /if (${Cursor.ID}) {
         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
         /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
         /goto :armpetend
       }
-      |/echo the line to parse is:${loadType}
-      /varset char_class ${Spawn[${Group.Member[${counter}]}].Class} 
-      /if (${char_class.Find[Shadow Knight]}) {
-         
-         |/echo Arm Pet: Doing ${char_class} loadout
+      
+      /if (${Me.Book[Grant Spectral Armaments]}) {
+        |/echo the line to parse is:${loadType}
+        /varset char_class ${Spawn[${Group.Member[${counter}]}].Class} 
+        /if (${char_class.Find[Shadow Knight]}) {
+          
+          |/echo Arm Pet: Doing ${char_class} loadout
+          
+          /if (${loadType.Find[fire]}) {
+
+            /varset primaryWeapon "Summoned: Fist of Flame"
+            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+
+          } else /if (${loadType.Find[ice]}) {
+            
+            /varset primaryWeapon "Summoned: Orb of Chilling Water"
+            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+            
+          } else /if (${loadType.Find[2dispell]}) {
+            
+            /varset primaryWeapon "Summoned: Wand of Dismissal"
+            /varset secondaryWeapon "Summoned: Wand of Dismissal"
+
+          } else {
+            
+            /varset primaryWeapon "Summoned: Wand of Dismissal"
+            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
         
-         /if (${loadType.Find[fire]}) {
-
-          /varset primaryWeapon "Summoned: Fist of Flame"
-          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-
-         } else /if (${loadType.Find[ice]}) {
-           
-          /varset primaryWeapon "Summoned: Orb of Chilling Water"
-          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-           
-         } else /if (${loadType.Find[2dispell]}) {
-           
-          /varset primaryWeapon "Summoned: Wand of Dismissal"
-          /varset secondaryWeapon "Summoned: Wand of Dismissal"
-
-         } else {
-          
-          /varset primaryWeapon "Summoned: Wand of Dismissal"
-          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-      
-         }
-      
-      } else /if (${char_class.Find[Druid]}) {
-         |/echo Arm Pet: Doing ${char_class} loadout
-         /if (${loadType.Find[fire]}) {
-
-          /varset primaryWeapon "Summoned: Fist of Flame"
-          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-
-         } else /if (${loadType.Find[ice]}) {
-           
-          /varset primaryWeapon "Summoned: Orb of Chilling Water"
-          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-           
-         } else /if (${loadType.Find[2dispell]}) {
-           
-          /varset primaryWeapon "Summoned: Wand of Dismissal"
-          /varset secondaryWeapon "Summoned: Wand of Dismissal"
-
-         } else {
-          
-          /varset primaryWeapon "Summoned: Wand of Dismissal"
-          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-      
-         }
-        |grouped mage/nec/enc here, will probably have to split out depending on new payloads
-      } else /if (${char_class.Find[Magician]} || ${char_class.Find[Necro]} || ${char_class.Find[Enchanter]}) {
-         |/echo Arm Pet: Doing ${char_class} loadout
-         /if (${loadType.Find[fire]}) {
-
-          /varset primaryWeapon "Summoned: Fist of Flame"
-          /varset secondaryWeapon "Summoned: Fist of Flame"
-
-         } else /if (${loadType.Find[ice]}) {
-           
-          /varset primaryWeapon "Summoned: Orb of Chilling Water"
-          /varset secondaryWeapon "Summoned: Orb of Chilling Water"
-           
-         } else /if (${loadType.Find[2dispell]}) {
-           
-          /varset primaryWeapon "Summoned: Wand of Dismissal"
-          /varset secondaryWeapon "Summoned: Wand of Dismissal"
-
-         } else {
-          
-          /varset primaryWeapon "Summoned: Mace of Temporal Distortion"
-          /varset secondaryWeapon "Summoned: Wand of Dismissal"
-      
-         }
+          }
         
-      } else {
-         |/echo Arm Pet: Doing Default ${char_class} loadout
-         /varset primaryWeapon "Summoned: Wand of Dismissal"
-         /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+        } else /if (${char_class.Find[Druid]}) {
+          |/echo Arm Pet: Doing ${char_class} loadout
+          /if (${loadType.Find[fire]}) {
 
+            /varset primaryWeapon "Summoned: Fist of Flame"
+            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+
+          } else /if (${loadType.Find[ice]}) {
+            
+            /varset primaryWeapon "Summoned: Orb of Chilling Water"
+            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+            
+          } else /if (${loadType.Find[2dispell]}) {
+            
+            /varset primaryWeapon "Summoned: Wand of Dismissal"
+            /varset secondaryWeapon "Summoned: Wand of Dismissal"
+
+          } else {
+            
+            /varset primaryWeapon "Summoned: Wand of Dismissal"
+            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+        
+          }
+          |grouped mage/nec/enc here, will probably have to split out depending on new payloads
+        } else /if (${char_class.Find[Magician]} || ${char_class.Find[Necro]} || ${char_class.Find[Enchanter]}) {
+          |/echo Arm Pet: Doing ${char_class} loadout
+          /if (${loadType.Find[fire]}) {
+
+            /varset primaryWeapon "Summoned: Fist of Flame"
+            /varset secondaryWeapon "Summoned: Fist of Flame"
+
+          } else /if (${loadType.Find[ice]}) {
+            
+            /varset primaryWeapon "Summoned: Orb of Chilling Water"
+            /varset secondaryWeapon "Summoned: Orb of Chilling Water"
+            
+          } else /if (${loadType.Find[2dispell]}) {
+            
+            /varset primaryWeapon "Summoned: Wand of Dismissal"
+            /varset secondaryWeapon "Summoned: Wand of Dismissal"
+
+          } else {
+            
+            /varset primaryWeapon "Summoned: Mace of Temporal Distortion"
+            /varset secondaryWeapon "Summoned: Wand of Dismissal"
+        
+          }
+          
+        } else {
+          |/echo Arm Pet: Doing Default ${char_class} loadout
+          /varset primaryWeapon "Summoned: Wand of Dismissal"
+          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+
+        }
+
+        /echo Selected Weapons are ${primaryWeapon} and ${secondaryWeapon}
+        /call summonUnpackAndSelect ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Armaments" "Folded Pack of Spectral Armaments" ${primaryWeapon} ${secondaryWeapon}
       }
-
-      /echo Selected Weapons are ${primaryWeapon} and ${secondaryWeapon}
-      
-      /call summonUnpackAndSelect ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Armaments" "Folded Pack of Spectral Armaments" ${primaryWeapon} ${secondaryWeapon}
-
       /if (${Cursor.ID}) {
         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
         /tell ${ChatSender}  Arm Pets: Error, check mage for detail.

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -64,13 +64,24 @@ sub event_petWeapons(line, ChatSender)
 /return
 
 #event armPets "#1# tells you, 'Arm Pets'"
-#event armPets "#1# tells you, 'Arm Pets #2# #3#'"
-#event armPets "<#1#> Arm Pets <#2#> <#3#>"
-#event armPets "<#1#> Arm Pets"
-sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
+#event armPets "#1# tells you, 'Arm Pets #2#'"
+|#event armPets "<#1#> Arm Pets <#2#> <#3#>"
+sub event_armPets(line, ChatSender, loadType)
  /echo |- event_armPets ==>
-
-
+  
+  /declare characterToWorkOn string local
+  
+  /if (${Bool[${loadType.Length}]}) {
+   /varset characterToWorkOn ${loadType.Token[2, ]}
+   /varset loadType ${loadType.Token[1, ]}
+   /if (${characterToWorkOn.Equal[NULL]}) {
+     |set to empty string
+     /varset characterToWorkOn  
+   }
+   |/echo LoadType:${loadType}
+   |/echo Character:${characterToWorkOn}
+  }
+  
   |first check that we have an empty slot
   /declare BackSlotThatIsOpen int 0
   /declare i int local
@@ -103,27 +114,26 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
     /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
     /goto :armpetend
   }
-  
+  |/echo got to for loop: ${characterToWorkOn.Length} : ${characterToWorkOn.Length}>0]}
   /for counter 0 to 5
-
     |if character name is supplied, skip everything but the character to work on. 
     |/echo checking character: [${characterToWorkOn}] vs [${Spawn[${Group.Member[${counter}]}].Name}]
    
-    /if (${characterToWorkOn.Length} && !${characterToWorkOn.Equal[${Spawn[${Group.Member[${counter}]}].Name}]}) /continue
-
+    /if (${characterToWorkOn.Length}>0 && !${characterToWorkOn.Equal[${Spawn[${Group.Member[${counter}]}].Name}]}) /continue
+    
     /varset bodytype ${Spawn[${Group.Member[${counter}]}].Pet.Body}
     |humanoid is to avoid bankers and such as they can be renamed.
     /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && ${Spawn[${Group.Member[${counter}]}].Pet.Level}>1) {
       
       /echo Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
  
-      |/call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
+      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
       /if (${Cursor.ID}) {
         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
         /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
         /goto :armpetend
       }
-      |/call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
+      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
       /if (${Cursor.ID}) {
         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
         /tell ${ChatSender}  Arm Pets: Error, check mage for detail.

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -117,13 +117,13 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
       
       /echo Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
  
-      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
+      |/call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
       /if (${Cursor.ID}) {
         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
         /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
         /goto :armpetend
       }
-      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
+      |/call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
       /if (${Cursor.ID}) {
         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
         /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
@@ -145,6 +145,11 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
           /varset primaryWeapon "Summoned: Orb of Chilling Water"
           /varset secondaryWeapon "Summoned: Spear of Maliciousness"
            
+         } else /if (${loadType.Find[2dispell]}) {
+           
+          /varset primaryWeapon "Summoned: Wand of Dismissal"
+          /varset secondaryWeapon "Summoned: Wand of Dismissal"
+
          } else {
           
           /varset primaryWeapon "Summoned: Wand of Dismissal"
@@ -164,6 +169,11 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
           /varset primaryWeapon "Summoned: Orb of Chilling Water"
           /varset secondaryWeapon "Summoned: Spear of Maliciousness"
            
+         } else /if (${loadType.Find[2dispell]}) {
+           
+          /varset primaryWeapon "Summoned: Wand of Dismissal"
+          /varset secondaryWeapon "Summoned: Wand of Dismissal"
+
          } else {
           
           /varset primaryWeapon "Summoned: Wand of Dismissal"
@@ -183,6 +193,11 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
           /varset primaryWeapon "Summoned: Orb of Chilling Water"
           /varset secondaryWeapon "Summoned: Orb of Chilling Water"
            
+         } else /if (${loadType.Find[2dispell]}) {
+           
+          /varset primaryWeapon "Summoned: Wand of Dismissal"
+          /varset secondaryWeapon "Summoned: Wand of Dismissal"
+
          } else {
           
           /varset primaryWeapon "Summoned: Mace of Temporal Distortion"
@@ -216,7 +231,7 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
 /return
 sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryItem)
 
-     /if (${Defined[armPetArray]}) /deletevar armPetArray
+      /if (${Defined[armPetArray]}) /deletevar armPetArray
       /declare armPetArray[1] string outer ${spellName}
       /if (${armPetArray.Size}) {
         |/echo building the spell array for heirlooms
@@ -226,21 +241,19 @@ sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryI
         /while (!${Select[${castReturn},CAST_SUCCESS]}) {
              /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
         }
-        
-         /if (${Defined[armPetArray]}) /deletevar armPetArray
+        /if (${Defined[armPetArray]}) /deletevar armPetArray
 
         /delay 1s
         |/echo done casting, put in inventory
-        /autoinventory
+        /call ClearCursor
         /delay 1s
         |/echo unfolding the bag to cursor
         /ItemNotify "${ItemName}" rightmouseup
         /delay 4s 
-        /autoinventory
-        /delay 3s !${Bool[${Cursor.ID}]}
+        /call ClearCursor
         /delay 1s
         /itemnotify "${primaryItem}" leftmouseup
-        /delay 1s
+        /delay 5s ${Bool[${Cursor.ID}]}
         /if (!${Cursor.ID}) {
           /echo summonUnpackAndSelect: Could not load parimary item to cursor, exiting
           /return
@@ -250,27 +263,67 @@ sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryI
         /call TrueTarget ${targetID}
         /if (${Target.ID} && ${Target.Distance}>19) /call MoveToLoc ${Target.Y} ${Target.X} 50 15
 
+
         |/echo giving primary item to pet
         /call giveItemOnCursorToTarget
         /if (${Cursor.ID}) {
           /echo summonUnpackAndSelect: Something went wrong and something is on your cursor, exiting.
           /return
         }
+
+        |check to see if we have a 2ndary item
+        /if (!${Bool[${FindItem[${secondaryItem}]}]}) {
+         
+         |we don't have the 2ndary item in this pack, summon the pack again and try again
+         |now delete the object
+          /itemnotify "Pouch of Quellious" leftmouseup
+          /delay 5s ${Bool[${Cursor.ID}]}
+          /if (${Cursor.Name.Find[Pouch of Quellious]}) {
+            /destroy
+          } else {
+            /echo summonUnpackAndSelect: Could not destroy bag, exiting
+            /return
+          }
+           /if (${Defined[armPetArray]}) /deletevar armPetArray
+          /declare armPetArray[1] string outer ${spellName}
+          /call BuildSpellArray "armPetArray" "armPetArray2D"
+          /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
+          /while (!${Select[${castReturn},CAST_SUCCESS]}) {
+              /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
+          }
+          /if (${Defined[armPetArray]}) /deletevar armPetArray
+          /delay 1s
+          |/echo done casting, put in inventory
+          /call ClearCursor
+          /delay 1s
+          |/echo unfolding the bag to cursor
+          /ItemNotify "${ItemName}" rightmouseup
+          /delay 4s 
+          /call ClearCursor
+          /delay 1s
+          /call TrueTarget ${targetID}
+        } 
+       
+        |2ndary item
         /itemnotify "${secondaryItem}" leftmouseup
-        /delay 1s
+        /delay 5s ${Bool[${Cursor.ID}]}
+        
         /if (!${Cursor.ID}) {
           /echo summonUnpackAndSelect: Could not load parimary item to cursor, exiting
           /return
         }
+
+        
         |/echo giving secondary item to pet
         /call giveItemOnCursorToTarget
-         /if (${Cursor.ID}) {
+        /if (${Cursor.ID}) {
           /echo summonUnpackAndSelect: Something went wrong and something is on your cursor, exiting.
           /return
         }
+      
         |now delete the object
         /itemnotify "Pouch of Quellious" leftmouseup
-        /delay 1s
+        /delay 5s ${Bool[${Cursor.ID}]}
         /if (${Cursor.Name.Find[Pouch of Quellious]}) {
            /destroy
         } else {

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -161,7 +161,7 @@ sub event_armPets(line, ChatSender, loadType)
             /varset primaryWeapon "Summoned: Orb of Chilling Water"
             /varset secondaryWeapon "Summoned: Spear of Maliciousness"
             
-          } else /if (${loadType.Find[2dispell]}) {
+          } else /if (${loadType.Find[2dispel]}) {
             
             /varset primaryWeapon "Summoned: Wand of Dismissal"
             /varset secondaryWeapon "Summoned: Wand of Dismissal"

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -185,7 +185,7 @@ sub event_armPets(line, ChatSender, loadType)
             /varset primaryWeapon "Summoned: Orb of Chilling Water"
             /varset secondaryWeapon "Summoned: Spear of Maliciousness"
             
-          } else /if (${loadType.Find[2dispell]}) {
+          } else /if (${loadType.Find[2dispel]}) {
             
             /varset primaryWeapon "Summoned: Wand of Dismissal"
             /varset secondaryWeapon "Summoned: Wand of Dismissal"
@@ -209,7 +209,7 @@ sub event_armPets(line, ChatSender, loadType)
             /varset primaryWeapon "Summoned: Orb of Chilling Water"
             /varset secondaryWeapon "Summoned: Orb of Chilling Water"
             
-          } else /if (${loadType.Find[2dispell]}) {
+          } else /if (${loadType.Find[2dispel]}) {
             
             /varset primaryWeapon "Summoned: Wand of Dismissal"
             /varset secondaryWeapon "Summoned: Wand of Dismissal"

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -123,7 +123,7 @@ sub event_armPets(line, ChatSender, loadType)
     /if (${characterToWorkOn.Length}>0 && !${characterToWorkOn.Equal[${Spawn[${Group.Member[${counter}]}].Name}]}) /continue
     
     /varset bodytype ${Spawn[${Group.Member[${counter}]}].Pet.Body}
-    |humanoid is to avoid bankers and such as they can be renamed.
+    
     /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && ${Spawn[${Group.Member[${counter}]}].Pet.Level}>1) {
       
       /echo Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -70,20 +70,38 @@ sub event_petWeapons(line, ChatSender)
 sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
  /echo |- event_armPets ==>
 
+
+  |first check that we have an empty slot
+  /declare BackSlotThatIsOpen int 0
+  /declare i int local
+  /for i 1 to 10
+  /if (!${Bool[${InvSlot[pack${i}].Item.ID}]}) {
+    /varset BackSlotThatIsOpen ${i}
+    /goto :bagslotcheckdone
+  }
+  /next i
+  :bagslotcheckdone
+  /if (${BackSlotThatIsOpen}==0) {
+    |no empty bag slot available
+    /tell ${ChatSender}  Arm Pets: No empty bag slot on mage. Exiting.
+    /goto :armpetend
+  } 
+
   /tell ${ChatSender} Starting the arming of group pets.
   |note for the weapons, you need na empty bag slot for this to work.
   /declare counter int local 0
   /declare bodytype string local
   /declare char_class string local
   /declare primaryWeapon string local
-  /declare secondaryWeapon string local
+  /declare secondaryWeapon string local 
 
   |/echo Character:${characterToWorkOn}
   |/echo loadType:${loadType}
 
   /if (${Cursor.ID}) {
     /echo Arm Pets: Something is on your cursor, exiting.
-    /return
+    /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
+    /goto :armpetend
   }
   
   /for counter 0 to 5
@@ -95,19 +113,21 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
 
     /varset bodytype ${Spawn[${Group.Member[${counter}]}].Pet.Body}
     |humanoid is to avoid bankers and such as they can be renamed.
-    /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && !${bodytype.Find[Humanoid]}) {
+    /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && ${Spawn[${Group.Member[${counter}]}].Pet.Level}>1) {
       
-      /echo working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
+      /echo Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
  
       /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
       /if (${Cursor.ID}) {
-         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /return
+        /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
+        /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
+        /goto :armpetend
       }
       /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
       /if (${Cursor.ID}) {
-         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /return
+        /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
+        /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
+        /goto :armpetend
       }
       |/echo the line to parse is:${loadType}
       /varset char_class ${Spawn[${Group.Member[${counter}]}].Class} 
@@ -150,8 +170,8 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
           /varset secondaryWeapon "Summoned: Spear of Maliciousness"
       
          }
-
-      } else /if (${char_class.Find[Magician]}) {
+        |grouped mage/nec/enc here, will probably have to split out depending on new payloads
+      } else /if (${char_class.Find[Magician]} || ${char_class.Find[Necro]} || ${char_class.Find[Enchanter]}) {
          |/echo Arm Pet: Doing ${char_class} loadout
          /if (${loadType.Find[fire]}) {
 
@@ -170,25 +190,6 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
       
          }
         
-      } else /if (${char_class.Find[Necro]}) {
-         |/echo Arm Pet: Doing ${char_class} loadout
-          /if (${loadType.Find[fire]}) {
-
-          /varset primaryWeapon "Summoned: Fist of Flame"
-          /varset secondaryWeapon "Summoned: Fist of Flame"
-
-         } else /if (${loadType.Find[ice]}) {
-           
-          /varset primaryWeapon "Summoned: Orb of Chilling Water"
-          /varset secondaryWeapon "Summoned: Orb of Chilling Water"
-           
-         } else {
-          
-          /varset primaryWeapon "Summoned: Mace of Temporal Distortion"
-          /varset secondaryWeapon "Summoned: Wand of Dismissal"
-      
-         }
-
       } else {
          |/echo Arm Pet: Doing Default ${char_class} loadout
          /varset primaryWeapon "Summoned: Wand of Dismissal"
@@ -201,15 +202,16 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
       /call summonUnpackAndSelect ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Armaments" "Folded Pack of Spectral Armaments" ${primaryWeapon} ${secondaryWeapon}
 
       /if (${Cursor.ID}) {
-         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /return
+        /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
+        /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
+        /goto :armpetend
       }
 
     }
     |/echo ${Spawn[${Group.Member[${counter}]}].Name} the ${Spawn[${Group.Member[${counter}]}].Class} has pet: ${Spawn[${Group.Member[${counter}]}].Pet.ID} which is ${bodytype}
   /next counter
   /tell ${ChatSender} Finished arming pets.
-
+:armpetend
 /if (${Debug} || ${Debug_MAG}) /echo <== event_armPets -|
 /return
 sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryItem)
@@ -227,6 +229,7 @@ sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryI
         
          /if (${Defined[armPetArray]}) /deletevar armPetArray
 
+        /delay 1s
         |/echo done casting, put in inventory
         /autoinventory
         /delay 1s
@@ -292,10 +295,11 @@ sub summonUnpackAndGive(targetID, spellName, ItemName)
         }
         
          /if (${Defined[armPetArray]}) /deletevar armPetArray
-
+        /delay 1s
         |/echo done casting, put in inventory
         /autoinventory
         /delay 3s !${Bool[${Cursor.ID}]}
+        /delay 1s
         |/echo unfolding the bag to cursor
         /ItemNotify "${ItemName}" rightmouseup
         /delay 3s

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -62,6 +62,273 @@ sub event_petWeapons(line, ChatSender)
   |/varset Debug_MAG FALSE
 /if (${Debug} || ${Debug_MAG}) /echo <== event_petWeapons -|
 /return
+
+#event armPets "#1# tells you, 'Arm Pets#2#'"
+#event armPets "<#1#> Arm Pets#2#"
+sub event_armPets(line, ChatSender, loadType)
+ /echo |- event_armPets ==>
+
+  /tell ${ChatSender} Starting the arming of group pets.
+  |note for the weapons, you need na empty bag slot for this to work.
+  /declare counter int local 0
+  /declare bodytype string local
+  /declare char_class string local
+  /declare primaryWeapon string local
+  /declare secondaryWeapon string local
+
+  /if (${Cursor.ID}) {
+    /echo Arm Pets: Something is on your cursor, exiting.
+    /return
+  }
+  /for counter 0 to 5
+
+    /varset bodytype ${Spawn[${Group.Member[${counter}]}].Pet.Body}
+    |humanoid is to avoid bankers and such as they can be renamed.
+    /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && !${bodytype.Find[Humanoid]}) {
+      
+      /echo working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
+ 
+      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
+      /if (${Cursor.ID}) {
+         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
+        /return
+      }
+      /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
+      /if (${Cursor.ID}) {
+         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
+        /return
+      }
+      |/echo the line to parse is:${loadType}
+      /varset char_class ${Spawn[${Group.Member[${counter}]}].Class} 
+      /if (${char_class.Find[Shadow Knight]}) {
+         
+         |/echo Arm Pet: Doing ${char_class} loadout
+        
+         /if (${loadType.Find[fire]}) {
+
+          /varset primaryWeapon "Summoned: Fist of Flame"
+          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+
+         } else /if (${loadType.Find[ice]}) {
+           
+          /varset primaryWeapon "Summoned: Orb of Chilling Water"
+          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+           
+         } else {
+          
+          /varset primaryWeapon "Summoned: Wand of Dismissal"
+          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+      
+         }
+      
+      } else /if (${char_class.Find[Druid]}) {
+         |/echo Arm Pet: Doing ${char_class} loadout
+         /if (${loadType.Find[fire]}) {
+
+          /varset primaryWeapon "Summoned: Fist of Flame"
+          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+
+         } else /if (${loadType.Find[ice]}) {
+           
+          /varset primaryWeapon "Summoned: Orb of Chilling Water"
+          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+           
+         } else {
+          
+          /varset primaryWeapon "Summoned: Wand of Dismissal"
+          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+      
+         }
+
+      } else /if (${char_class.Find[Magician]}) {
+         |/echo Arm Pet: Doing ${char_class} loadout
+         /if (${loadType.Find[fire]}) {
+
+          /varset primaryWeapon "Summoned: Fist of Flame"
+          /varset secondaryWeapon "Summoned: Fist of Flame"
+
+         } else /if (${loadType.Find[ice]}) {
+           
+          /varset primaryWeapon "Summoned: Orb of Chilling Water"
+          /varset secondaryWeapon "Summoned: Orb of Chilling Water"
+           
+         } else {
+          
+          /varset primaryWeapon "Summoned: Mace of Temporal Distortion"
+          /varset secondaryWeapon "Summoned: Wand of Dismissal"
+      
+         }
+        
+      } else /if (${char_class.Find[Necro]}) {
+         |/echo Arm Pet: Doing ${char_class} loadout
+          /if (${loadType.Find[fire]}) {
+
+          /varset primaryWeapon "Summoned: Fist of Flame"
+          /varset secondaryWeapon "Summoned: Fist of Flame"
+
+         } else /if (${loadType.Find[ice]}) {
+           
+          /varset primaryWeapon "Summoned: Orb of Chilling Water"
+          /varset secondaryWeapon "Summoned: Orb of Chilling Water"
+           
+         } else {
+          
+          /varset primaryWeapon "Summoned: Mace of Temporal Distortion"
+          /varset secondaryWeapon "Summoned: Wand of Dismissal"
+      
+         }
+
+      } else {
+         |/echo Arm Pet: Doing Default ${char_class} loadout
+         /varset primaryWeapon "Summoned: Wand of Dismissal"
+         /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+
+      }
+
+      /echo Selected Weapons are ${primaryWeapon} and ${secondaryWeapon}
+      
+      /call summonUnpackAndSelect ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Armaments" "Folded Pack of Spectral Armaments" ${primaryWeapon} ${secondaryWeapon}
+
+      /if (${Cursor.ID}) {
+         /echo Arm Pets: Something went wrong and something is on your cursor, exiting.
+        /return
+      }
+
+    }
+    |/echo ${Spawn[${Group.Member[${counter}]}].Name} the ${Spawn[${Group.Member[${counter}]}].Class} has pet: ${Spawn[${Group.Member[${counter}]}].Pet.ID} which is ${bodytype}
+  /next counter
+  /tell ${ChatSender} Finished arming pets.
+
+/if (${Debug} || ${Debug_MAG}) /echo <== event_armPets -|
+/return
+sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryItem)
+
+     /if (${Defined[armPetArray]}) /deletevar armPetArray
+      /declare armPetArray[1] string outer ${spellName}
+      /if (${armPetArray.Size}) {
+        |/echo building the spell array for heirlooms
+
+        /call BuildSpellArray "armPetArray" "armPetArray2D"
+        /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
+        /while (!${Select[${castReturn},CAST_SUCCESS]}) {
+             /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
+        }
+        
+         /if (${Defined[armPetArray]}) /deletevar armPetArray
+
+        |/echo done casting, put in inventory
+        /autoinventory
+        /delay 1s
+        |/echo unfolding the bag to cursor
+        /ItemNotify "${ItemName}" rightmouseup
+        /delay 4s 
+        /autoinventory
+        /delay 3s !${Bool[${Cursor.ID}]}
+        /delay 1s
+        /itemnotify "${primaryItem}" leftmouseup
+        /delay 1s
+        /if (!${Cursor.ID}) {
+          /echo summonUnpackAndSelect: Could not load parimary item to cursor, exiting
+          /return
+        }
+
+        |/echo getting the target of the pet
+        /call TrueTarget ${targetID}
+        /if (${Target.ID} && ${Target.Distance}>19) /call MoveToLoc ${Target.Y} ${Target.X} 50 15
+
+        |/echo giving primary item to pet
+        /call giveItemOnCursorToTarget
+        /if (${Cursor.ID}) {
+          /echo summonUnpackAndSelect: Something went wrong and something is on your cursor, exiting.
+          /return
+        }
+        /itemnotify "${secondaryItem}" leftmouseup
+        /delay 1s
+        /if (!${Cursor.ID}) {
+          /echo summonUnpackAndSelect: Could not load parimary item to cursor, exiting
+          /return
+        }
+        |/echo giving secondary item to pet
+        /call giveItemOnCursorToTarget
+         /if (${Cursor.ID}) {
+          /echo summonUnpackAndSelect: Something went wrong and something is on your cursor, exiting.
+          /return
+        }
+        |now delete the object
+        /itemnotify "Pouch of Quellious" leftmouseup
+        /delay 1s
+        /if (${Cursor.Name.Find[Pouch of Quellious]}) {
+           /destroy
+        } else {
+          /echo summonUnpackAndSelect: Could not destroy bag, exiting
+          /return
+        }
+
+      }
+
+/return
+sub summonUnpackAndGive(targetID, spellName, ItemName)
+
+     /if (${Defined[armPetArray]}) /deletevar armPetArray
+      /declare armPetArray[1] string outer ${spellName}
+      /if (${armPetArray.Size}) {
+        |/echo building the spell array for heirlooms
+
+        /call BuildSpellArray "armPetArray" "armPetArray2D"
+        /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
+        /while (!${Select[${castReturn},CAST_SUCCESS]}) {
+             /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
+        }
+        
+         /if (${Defined[armPetArray]}) /deletevar armPetArray
+
+        |/echo done casting, put in inventory
+        /autoinventory
+        /delay 3s !${Bool[${Cursor.ID}]}
+        |/echo unfolding the bag to cursor
+        /ItemNotify "${ItemName}" rightmouseup
+        /delay 3s
+        |/echo getting the target of the pet
+        /call TrueTarget ${targetID}
+        /if (${Target.ID} && ${Target.Distance}>19) /call MoveToLoc ${Target.Y} ${Target.X} 50 15
+        /call giveItemOnCursorToTarget
+        /if (${Cursor.ID}) {
+          /echo summonUnpackAndGive: Something went wrong and something is on your cursor, exiting.
+          /return
+        }
+      }
+
+/return
+sub giveItemOnCursorToTarget()
+
+    /if (${Defined[retryWeapTimer]}) /deletevar retryWeapTimer
+    /declare retryWeapTimer timer local 10s
+
+    |/echo trying to trade heirloom pack to pet
+    :OpenTrade_Loop
+    
+    /click left target
+    /delay 3s ${Window[GiveWnd].Open}
+    /if (!${Window[GiveWnd].Open}) {
+        /if (${retryWeapTimer} && ${Cursor.ID}) {
+          /goto :OpenTrade_Loop
+        } else {
+          /echo Failed to open trade with ${Target.CleanName}.
+        }
+    } else {
+        :WaitAccept_Loop
+        /notify GiveWnd GVW_Give_Button LeftMouseUp
+        /delay 1s !${Window[GiveWnd].Open}
+        /if (${Window[GiveWnd].Open}) {
+          /if (${retryWeapTimer}) {
+            /goto :WaitAccept_Loop
+          } else {
+            /echo Failed to open trade with ${Target.CleanName}.
+          }
+        }
+      }
+
+/return
 |----------------------------------------------------------------------------|
 SUB give_PetsWeapons(autoWeap)
   /declare p int local
@@ -335,6 +602,7 @@ SUB MAG_Background_Events
 **|
   /doevents auto_coh
   /doevents petWeapons
+  /doevents armPets
 /RETURN
 
 |----------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -63,9 +63,11 @@ sub event_petWeapons(line, ChatSender)
 /if (${Debug} || ${Debug_MAG}) /echo <== event_petWeapons -|
 /return
 
-#event armPets "#1# tells you, 'Arm Pets#2#'"
-#event armPets "<#1#> Arm Pets#2#"
-sub event_armPets(line, ChatSender, loadType)
+#event armPets "#1# tells you, 'Arm Pets'"
+#event armPets "#1# tells you, 'Arm Pets #2# #3#'"
+#event armPets "<#1#> Arm Pets <#2#> <#3#>"
+#event armPets "<#1#> Arm Pets"
+sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
  /echo |- event_armPets ==>
 
   /tell ${ChatSender} Starting the arming of group pets.
@@ -76,11 +78,20 @@ sub event_armPets(line, ChatSender, loadType)
   /declare primaryWeapon string local
   /declare secondaryWeapon string local
 
+  |/echo Character:${characterToWorkOn}
+  |/echo loadType:${loadType}
+
   /if (${Cursor.ID}) {
     /echo Arm Pets: Something is on your cursor, exiting.
     /return
   }
+  
   /for counter 0 to 5
+
+    |if character name is supplied, skip everything but the character to work on. 
+    /echo checking character: [${characterToWorkOn}] vs [${Spawn[${Group.Member[${counter}]}].Name}]
+   
+    /if (${characterToWorkOn.Length} && !${characterToWorkOn.Equal[${Spawn[${Group.Member[${counter}]}].Name}]}) /continue
 
     /varset bodytype ${Spawn[${Group.Member[${counter}]}].Pet.Body}
     |humanoid is to avoid bankers and such as they can be renamed.

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -89,7 +89,7 @@ sub event_armPets(line, ChatSender, loadType, characterToWorkOn)
   /for counter 0 to 5
 
     |if character name is supplied, skip everything but the character to work on. 
-    /echo checking character: [${characterToWorkOn}] vs [${Spawn[${Group.Member[${counter}]}].Name}]
+    |/echo checking character: [${characterToWorkOn}] vs [${Spawn[${Group.Member[${counter}]}].Name}]
    
     /if (${characterToWorkOn.Length} && !${characterToWorkOn.Equal[${Spawn[${Group.Member[${counter}]}].Name}]}) /continue
 

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -81,6 +81,13 @@ SUB heal_tanks
 
 	/if (${Bool[${currentBot}]}) {
 		/call e3_Cast ${NetBots[${currentBot}].ID} "tankHeals2D" ${currentSpellIndx}
+		/if (${UseNecroHealOrbs} && ${Target.PctHPs} < 90) {
+			/if (${Me.ItemReady[Orb of Shadows]}) {
+				/call castSimpleSpell "Orb of Shadows" ${NetBots[${currentBot}].ID}
+			} else /if (${Me.ItemReady[Orb of Souls]}) {
+				/call castSimpleSpell "Orb of Souls" ${NetBots[${currentBot}].ID}
+			}
+		}
 	}	
 	
 /if (${Debug} || ${Debug_Heals}) /echo <== heal_tanks -|
@@ -120,7 +127,6 @@ SUB heal_importantBots
 		/varset importantHeals2D[${currentSpellIndx},${iSubToRun}] check_TankAndXTargetNeedHeal
 		|-Our cast may have been interrupted so need to do a quick check on heals
 		/call e3_Cast ${NetBots[${currentBot}].ID} "importantHeals2D" ${currentSpellIndx}
-
 		/if (${castReturn.Equal[CAST_INTERRUPTED]}) {
 			/call heal_tanks
 			/call heal_xtargets
@@ -220,6 +226,13 @@ SUB heal_xtargets
 
 	/if (${Bool[${currentBot}]}) {
 		/call e3_Cast ${Me.XTarget[${currentBot}].ID} "xtargetHeals2D" ${currentSpellIndx}	
+		/if (${UseNecroHealOrbs} && ${Target.PctHPs} < 90) {
+			/if (${Me.ItemReady[Orb of Shadows]}) {
+				/call castSimpleSpell "Orb of Shadows" ${NetBots[${currentBot}].ID}
+			} else /if (${Me.ItemReady[Orb of Souls]}) {
+				/call castSimpleSpell "Orb of Souls" ${NetBots[${currentBot}].ID}
+			}
+		}
 	}
 /if (${Debug} || ${Debug_Heals}) /echo <== heal_xtargets -|
 /RETURN
@@ -863,6 +876,8 @@ SUB heal_Setup
   /declare hotPets bool outer FALSE
   /declare UseNecroHealOrbs bool outer FALSE
 
+
+
   /call ListToArray "hotTankNoStack"		  "${hotTankNoStackStr}"		  ","
   /call ListToArray "hotImportantNoStack" "${hotImportantNoStackStr}" ","
   /call ListToArray "hotAllNoStack"		    "${hotAllNoStackStr}" 		  ","
@@ -984,7 +999,7 @@ SUB heal_CharacterSettings
 		/call WriteToIni "${Character_Ini},Heals,All Heal"
 		/call WriteToIni "${Character_Ini},Heals,XTarget Heal"
 		/call WriteToIni "${Character_Ini},Heals,Pet Heal"
-		/call WriteToIni "${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)"
+		/call WriteToIni "${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)" "On"
     /if (${Select[${Me.Class.ShortName},CLR,DRU,PAL,SHM]}) /call WriteToIni "${Character_Ini},Heals,Heal Over Time Spell"
     /if (${Select[${Me.Class.ShortName},CLR,DRU,PAL]})	/call WriteToIni "${Character_Ini},Heals,Group Heal"
     |/if (${Select[${Me.Class.ShortName},CLR,SHM]}) /call WriteToIni "${Character_Ini},Heals,;Group Hot" "Not Implemented"

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -861,6 +861,7 @@ SUB heal_Setup
   /declare hotImportant bool outer FALSE
   /declare hotAll bool outer FALSE
   /declare hotPets bool outer FALSE
+  /declare UseNecroHealOrbs bool outer FALSE
 
   /call ListToArray "hotTankNoStack"		  "${hotTankNoStackStr}"		  ","
   /call ListToArray "hotImportantNoStack" "${hotImportantNoStackStr}" ","
@@ -891,6 +892,7 @@ SUB heal_SpellArrays
     /call IniToArrayV "${Character_Ini},Heals,Pet Heal#"              petHeals
     /call IniToArrayV "${Character_Ini},Heals,Heal Over Time Spell#"  hotSpells
     /call IniToArrayV "${Character_Ini},Heals,Group Heal#"            groupHeals
+	/if (${Bool[${Ini[${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)]}]}) /call iniToVarV "${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)" UseNecroHealOrbs bool outer
   }
 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~|
 | lets healers break invis to cast heal
@@ -982,6 +984,7 @@ SUB heal_CharacterSettings
 		/call WriteToIni "${Character_Ini},Heals,All Heal"
 		/call WriteToIni "${Character_Ini},Heals,XTarget Heal"
 		/call WriteToIni "${Character_Ini},Heals,Pet Heal"
+		/call WriteToIni "${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)"
     /if (${Select[${Me.Class.ShortName},CLR,DRU,PAL,SHM]}) /call WriteToIni "${Character_Ini},Heals,Heal Over Time Spell"
     /if (${Select[${Me.Class.ShortName},CLR,DRU,PAL]})	/call WriteToIni "${Character_Ini},Heals,Group Heal"
     |/if (${Select[${Me.Class.ShortName},CLR,SHM]}) /call WriteToIni "${Character_Ini},Heals,;Group Hot" "Not Implemented"

--- a/Macros/e3 Includes/e3_PrivateCode.inc
+++ b/Macros/e3 Includes/e3_PrivateCode.inc
@@ -1,0 +1,4 @@
+| We will no longer provide commits to this specific .inc file from GitHub.
+| This include file is only here as a placeholder for 'special code' people make but do not want to share.
+| Add your code in here and know we won't merge code over top of it. 
+| We hope this makes future E3 updates easier for you to accept.

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -50,17 +50,18 @@ SUB e3_Setup(modeSelect)
 	} else {
 		/declare serverNameForINI string outer PEQTGC
 	}
+	/declare reloadOnLoot bool outer FALSE
+	/declare missingSpellItem string outer
+	/declare numInventorySlots int outer 10
+	/call BuildSpellArrayDefinedValues
 
-  /declare reloadOnLoot bool outer FALSE
-  /declare missingSpellItem string outer
-  /declare numInventorySlots int outer 10
 	/if (${modeSelect.Equal[Debug]}) /varset Debug TRUE
 	| The file path for e3 Data.ini will still need to be updated in corresponding includes because you must use /noparse to write variables to inis.
 	/declare MacroData_Ini string outer e3 Macro Inis\e3 Data.ini
 	/call check_Plugins
 	/echo Loading e3 v${macroVersion}...
 	| create a macro data
-   /if (!${${IniMode}[${MacroData_Ini}].Length}) {
+	/if (!${${IniMode}[${MacroData_Ini}].Length}) {
 		/echo Welcome to e3! preforming first time setup...
 		/call make_macroDataIni
 	}
@@ -89,8 +90,8 @@ SUB e3_Setup(modeSelect)
 	} else {
 			/declare Character_Ini string outer ${${IniMode}[${MacroData_Ini},File Paths,Bot Settings]}\\${Me.CleanName}_${serverNameForINI}.ini
 			/if (!${Bool[${Ini[${Character_Ini}]}]} && ${Bool[${Ini[${Character_Ini.Replace[Lazarus,PEQTGC]}]}]}) {
-				/echo WARNING!!!!
-				/echo INI for ${Me.CleanName}_${serverNameForINI}.ini does not exist but INI for PEQTGC does. Defaulting to ${Me.CleanName}_PEQTGC.ini
+				|/echo WARNING!!!!
+				|/echo INI for ${Me.CleanName}_${serverNameForINI}.ini does not exist but INI for PEQTGC does. Defaulting to ${Me.CleanName}_PEQTGC.ini
 				/varset serverNameForINI PEQTGC
 				/varset Character_Ini ${Character_Ini.Replace[Lazarus,PEQTGC]}
 			}
@@ -144,6 +145,7 @@ SUB e3_Setup(modeSelect)
 		/call WriteToIni "${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)" On
 	}
 
+	
 
 	/echo e3 loaded - Turbo ${classTurbo}
 	

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -139,6 +139,12 @@ SUB e3_Setup(modeSelect)
   /if (${${IniMode}[${advSettings_Ini},Turbo,${Me.Class.ShortName}].Length}) /declare classTurbo int outer ${${IniMode}[${advSettings_Ini},Turbo,${Me.Class.ShortName}]}
   /squelch /turbo ${classTurbo}
 
+	|Ewiclip: Adding auto-casting of Necromancer orb heals. 
+	/if (${Bool[${Ini[${Character_Ini},Heals]}]} && !${Bool[${Ini[${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)]}]}) {
+		/call WriteToIni "${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)" On
+	}
+
+
 	/echo e3 loaded - Turbo ${classTurbo}
 	
 	/if (${Debug}) {

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -1,6 +1,7 @@
 |--------------------------------------------------------------------|
 |- Contains setup functions for e3.mac								              -|
 |--------------------------------------------------------------------|
+#include e3 Includes\e3_PrivateCode.inc
 #include e3 Includes\e3_Alerts.inc
 #include e3 Includes\e3_Assists.inc
 #include e3 Includes\e3_Background.inc

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -290,7 +290,8 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
   	/if (!${Defined[iIfs]})		/declare iIfs int outer 42
   
 	/declare i int local
-	/declare printAll bool local FALSE
+	/declare printAll bool local False
+	/declare printMin bool local False
 	|first loop through array to ensure i can identify all listed spells
 	/declare tmp_castname string local
 	/declare remove_index int local
@@ -330,7 +331,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 	/for i 1 to ${${ArrayName}.Size}
     | get SpellName
 		/varset ${NewArrayName}[${i},${iCastName}] ${${ArrayName}[${i}].Arg[1,/]}
-		/if (${printAll}) /echo CastName ${${NewArrayName}[${i},${iCastName}]}
+		/if (${printAll} || ${printMin}) /echo CastName ${${NewArrayName}[${i},${iCastName}]}
 
 		| get CastType
 		/if (${Bool[${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell}]}) {
@@ -344,7 +345,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		} else {
       /varset ${NewArrayName}[${i},${iCastType}] Item
 		}
-    /if (${printAll}) /echo CastType ${${NewArrayName}[${i},${iCastType}]}
+    /if (${printAll}  || ${printMin}) /echo CastType ${${NewArrayName}[${i},${iCastType}]}
 		
 		| get TargetType
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -408,7 +409,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
       /varset	${NewArrayName}[${i},${iDuration}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Duration}
     }
 
-		/if (${printAll}) /echo SpellDuration ${${NewArrayName}[${i},${iDuration}]}
+		/if (${printAll}  || ${printMin}) /echo SpellDuration ${${NewArrayName}[${i},${iDuration}]}
 		
 		| get RecastTime
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -418,7 +419,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
 			/varset	${NewArrayName}[${i},${iRecastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].RecastTime}			
 		} 
-		/if (${printAll}) /echo RecastTime ${${NewArrayName}[${i},${iRecastTime}]}
+		/if (${printAll}|| ${printMin}) /echo RecastTime ${${NewArrayName}[${i},${iRecastTime}]}
 
 		| get RecoveryTime
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -438,7 +439,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
 			/varset	${NewArrayName}[${i},${iMyCastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyCastTime}			
 		} 
-		/if (${printAll}) /echo ${NewArrayName} ${i}  MyCastTime ${${NewArrayName}[${i},${iMyCastTime}]}
+		/if (${printAll} || ${printMin}) /echo ${NewArrayName} ${i}  MyCastTime ${${NewArrayName}[${i},${iMyCastTime}]}
 		
 		| get MyRange
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -581,7 +582,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 			/call argueString Delay| "${${ArrayName}[${i}]}"
 			/varset ${NewArrayName}[${i},${iDelay}] ${c_argueString}
 		}
-		/if (${printAll}) /echo Delay ${${NewArrayName}[${i},${iDelay}]}		
+		/if (${printAll} || ${printMin}) /echo Delay ${${NewArrayName}[${i},${iDelay}]}		
 
 		| get CastID
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -1243,3 +1243,8 @@ SUB Build_Class_Ini(Ini_File)
 	/ini "${Ini_File}" Wizard "Wizard is for"
 /if (${Debug}) /echo |- Build_Class_Ini ==>
 /RETURN
+
+#event sendInstanceInvites "#1# tells you, 'dzadd'"
+SUB event_sendInstanceInvites(line, ChatSender)
+	/dzadd ${ChatSender}
+/return

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -184,11 +184,12 @@ SUB ListToArray(ArrayName, Data, delimiter)
 	/next i
 /RETURN ${ArrayName}
 
-|--------------------------------------------------------|
-|- 2D array for spell casting/full e3_casting use
-|--------------------------------------------------------|
-SUB BuildSpellArray(ArrayName, NewArrayName)
-  /if (${Debug}) /echo Array ${ArrayName} ${NewArrayName}
+
+|---------------------------------------------------------------------|
+|- Define variables used by BuildSpellArray and called in e3_Setup
+|---------------------------------------------------------------------|
+Sub BuildSpellArrayDefinedValues()
+
 	/if (!${Defined[SpellProp]}) {
 		/declare SpellProp[43] string outer 0
 		/varset SpellProp[1] CastName
@@ -228,8 +229,6 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		/varset SpellProp[35] PctAggro
 		/varset SpellProp[36] Zone
     	/varset SpellProp[37] MinSick
-		|-- Ewiclip Mod--------------
-		|-- Properties for special DoT code.
 		/varset SpellProp[38] AllowSpellSwap
 		/varset SpellProp[39] NoEarlyRecast
 		/varset SpellProp[40] NoStack
@@ -237,12 +236,6 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		|----------------------------
     	/varset SpellProp[42] Ifs
 	}
-
-  /if (${Defined[${NewArrayName}]}) /deletevar ${NewArrayName}
-	/declare ${NewArrayName}[${${ArrayName}.Size},${SpellProp.Size}] string outer 0
-	|/echo NA ${NewArrayName} ${ArrayName} ${${ArrayName}.Size} ${SpellProp.Size} ${${NewArrayName}.Size[1]}
-	/declare errMsg string local Review entry and restart macro
-    
 	/if (!${Defined[iCastName]})		/declare iCastName int outer 1
 	/if (!${Defined[iCastType]})		/declare iCastType int outer 2
 	/if (!${Defined[iTargetType]})		/declare iTargetType int outer 3
@@ -280,60 +273,80 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
   	/if (!${Defined[iPctAggro]})		/declare iPctAggro int outer 35
 	/if (!${Defined[iZone]})		/declare iZone int outer 36
   	/if (!${Defined[iMinSick]})		/declare iMinSick int outer 37
-	|-- Ewiclip Mod--------------
-	|-- Properties for special DoT code.
 	/if (!${Defined[iAllowSpellSwap]})		/declare iAllowSpellSwap int outer 38
 	/if (!${Defined[iNoEarlyRecast]})		/declare iNoEarlyRecast int outer 39
 	/if (!${Defined[iNoStack]})		/declare iNoStack int outer 40
 	/if (!${Defined[iTriggerSpell]})		/declare iTriggerSpell int outer 41
-	|----------------------------
   	/if (!${Defined[iIfs]})		/declare iIfs int outer 42
-  
+
+/return
+
+|--------------------------------------------------------|
+|- 2D array for spell casting/full e3_casting use
+|--------------------------------------------------------|
+
+|Note, for whatever reason when chaining methods in mq2, you cannot have the same variable name to your sub call as from your input. ??????
+Sub BuildSpellArray(ArrayNameFromBuildSpellArray, NewArrayNameFromBuildSpellArray)
+
+	/call BuildSpellArrayBase "${ArrayNameFromBuildSpellArray}" "${NewArrayNameFromBuildSpellArray}" FALSE
+
+/return
+
+SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
+	
+	/if (${Debug}) /echo Array ${ArrayName} ${NewArrayName}
+	/if (${Defined[${NewArrayName}]}) /deletevar ${NewArrayName}
+	
+	/declare ${NewArrayName}[${${ArrayName}.Size},${SpellProp.Size}] string outer 0
+	|/echo NA ${NewArrayName} ${ArrayName} ${${ArrayName}.Size} ${SpellProp.Size} ${${NewArrayName}.Size[1]}
+	/declare errMsg string local Review entry and restart macro
+
 	/declare i int local
+	|for item information lookup optimization
+	/declare invSlot int local 0
+	/declare bagSlot int local 0
+
 	/declare printAll bool local False
 	/declare printMin bool local False
 	|first loop through array to ensure i can identify all listed spells
 	/declare tmp_castname string local
-	/declare remove_index int local
-  /for i 1 to ${${ArrayName}.Size}
-    /varset remove_index ${i}
-    /varset tmp_castname ${${ArrayName}[${i}].Arg[1,/]}
-    | get CastType
-    /if (${Me.Book[${tmp_castname}]}) {
-      /varset remove_index 0
-    } else /if (${Me.AltAbility[${tmp_castname}]}) {
-      /varset remove_index 0
-    } else /if (${Me.CombatAbility[${tmp_castname}]}) {
-      /varset remove_index 0
-    } else /if (${Me.Ability[${tmp_castname}]}) {
-      /varset remove_index 0
-    } else {
-      |default to item - no way to validate an item thats on my corpse
-      /if (!${FindItem[=${tmp_castname}].ID}) {
-
-        /if (!${Bool[${Me.Inventory[Chest]}]} && !${Me.Platinum}) {
-          /varset reloadOnLoot TRUE
-          /varset missingSpellItem ${tmp_castname}
-          /call RemoveArrayElement "${ArrayName}" "${ArrayName}[${i}]"
-        } else /if (${tmp_castname.Find[Molten Orb]} && ${Bool[${Me.Book[Summon: Molten Orb]}]}) {
-          |/echo This is ok, mage handling
-        } else {
-          /varset reloadOnLoot TRUE
-          /varset missingSpellItem ${tmp_castname}
-          /bc [${${ArrayName}[${i}]}] : ${tmp_castname} i do not have this spell|aa|ability|disc|item accessible
-          /beep
-          /call RemoveArrayElement "${ArrayName}" "${ArrayName}[${i}]"
-        }
-      }
-    }
-  /next i
-
+	|check to see if the spell/aa/etc actually exists.
 	/for i 1 to ${${ArrayName}.Size}
-    | get SpellName
-		/varset ${NewArrayName}[${i},${iCastName}] ${${ArrayName}[${i}].Arg[1,/]}
-		/if (${printAll} || ${printMin}) /echo CastName ${${NewArrayName}[${i},${iCastName}]}
+		
+		/varset tmp_castname ${${ArrayName}[${i}].Arg[1,/]}
+		|First check for super common items to ignore this
+		/if (!(${tmp_castname.Equal[Molten Orb]} || ${tmp_castname.Equal[Orb of Shadows]}|| ${tmp_castname.Equal[Orb of Souls]})) {
+			| check to see if its a Spell/AA/CombatAbility/Ability, and if not...
+			/if (!(${Me.Book[${tmp_castname}]}||${Me.AltAbility[${tmp_castname}]}||${Me.CombatAbility[${tmp_castname}]}||${Me.Ability[${tmp_castname}]})) {
+				
+				|default to item - no way to validate an item thats on my corpse
+				/if (!${FindItem[=${tmp_castname}].ID}) {
 
-		| get CastType
+					/if (!${Bool[${Me.Inventory[Chest]}]} && !${Me.Platinum}) {
+						/varset reloadOnLoot TRUE
+						/varset missingSpellItem ${tmp_castname}
+						/call RemoveArrayElement "${ArrayName}" "${ArrayName}[${i}]"
+					} else {
+						/varset reloadOnLoot TRUE
+						/varset missingSpellItem ${tmp_castname}
+						/bc [${${ArrayName}[${i}]}] : ${tmp_castname} i do not have this spell|aa|ability|disc|item accessible
+						/beep
+						/call RemoveArrayElement "${ArrayName}" "${ArrayName}[${i}]"
+					}
+				}
+			}
+		}
+		
+	/next i
+
+	/declare isHealArray bool local ${Select[${ArrayName},tankHeals,importantHeals,allHeals,hotSpells,groupHeals,lifeSupport,petHeal,petHeals,lifeTaps,xtargetHeals]
+	/declare isCastTargetArray bool local ${Select[${ArrayName},BotBuffs,PetBuffs,CombatBuffs,cureTargets]}
+	/for i 1 to ${${ArrayName}.Size}
+		| get SpellName
+		/varset ${NewArrayName}[${i},${iCastName}] ${${ArrayName}[${i}].Arg[1,/]}
+		| get CastTarget
+		/if (${isCastTargetArray}) /varset ${NewArrayName}[${i},${iCastTarget}] ${${ArrayName}[${i}].Arg[2,/]}
+		
 		/if (${Bool[${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell}]}) {
 			/varset ${NewArrayName}[${i},${iCastType}] AA
 		} else /if (${Me.Book[${${NewArrayName}[${i},${iCastName}]}]}) {
@@ -343,378 +356,355 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		} else /if (${Me.Ability[${${NewArrayName}[${i},${iCastName}]}]}) {
 			/varset ${NewArrayName}[${i},${iCastType}] Ability			
 		} else {
-      /varset ${NewArrayName}[${i},${iCastType}] Item
+			/varset ${NewArrayName}[${i},${iCastType}] Item
 		}
-    /if (${printAll}  || ${printMin}) /echo CastType ${${NewArrayName}[${i},${iCastType}]}
 		
-		| get TargetType
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iTargetType}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.TargetType}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iTargetType}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.TargetType}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-			/varset	${NewArrayName}[${i},${iTargetType}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].TargetType}			
-		} 
-		/if (${printAll}) /echo TargetType ${${NewArrayName}[${i},${iTargetType}]}
+		|set the normal defaults
+		/varset ${NewArrayName}[${i},${iSpellGem}] ${DefaultGem}
+		/varset ${NewArrayName}[${i},${iMaxTries}] 5
+		/varset ${NewArrayName}[${i},${iCheckFor}] -1
+		/varset ${NewArrayName}[${i},${iMaxMana}] 100
+		/varset ${NewArrayName}[${i},${iMinHP}] 70
+		/varset	${NewArrayName}[${i},${iZone}] All
+		/varset ${NewArrayName}[${i},${iIfs}] TRUE
+		|don't need to set int values of 0 which are default for ints
+		|/varset ${NewArrayName}[${i},${iMinEnd}] 0
+		|default casting while invis to 0 which impies no casting while invis
+		|/varset	${NewArrayName}[${i},${iCastInvis}] 0
+		|/varset	${NewArrayName}[${i},${iMinSick}] 0
+		|/varset ${NewArrayName}[${i},${iAllowSpellSwap}] 0
+		|/varset ${NewArrayName}[${i},${iNoEarlyRecast}] 0
+		|/varset ${NewArrayName}[${i},${iNoStack}] 0
+		|/varset	${NewArrayName}[${i},${iTriggerSpell}] 0
+		|default PctAggro to 0, cast even when aggro target
+		|/varset	${NewArrayName}[${i},${iPctAggro}] 0
 
-		| get SpellGem
-		/if (${${ArrayName}[${i}].Find[/Gem|]}) {
-			/call argueString Gem| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iSpellGem}] ${c_argueString}
-		} else {
-		  /varset ${NewArrayName}[${i},${iSpellGem}] ${DefaultGem}
-		}
-		/if (${printAll}) /echo SpellGem ${${NewArrayName}[${i},${iSpellGem}]}
-		
-		| get SubToRun
-		/if (${${ArrayName}[${i}].Find[/SubToRun|]}) {
-			/call argueString SubToRun| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iSubToRun}] ${c_argueString}
-		}
-		/if (${printAll}) /echo SubToRun ${${NewArrayName}[${i},${iSubToRun}]}
-		
-		| get GiveUpTimer
-		/if (${${ArrayName}[${i}].Find[/GiveUpTimer|]}) {
-			/call argueString GiveUpTimer| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iGiveUpTimer}] ${c_argueString}
-		}
-		/if (${printAll}) /echo GiveUpTimer ${${NewArrayName}[${i},${iGiveUpTimer}]}
-		
-		| get MaxTries
-		/if (${${ArrayName}[${i}].Find[/MaxTries|]}) {
-			/call argueString MaxTries| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iMaxTries}] ${c_argueString}
-		} else {
-      /varset ${NewArrayName}[${i},${iMaxTries}] 5
-		}
-		/if (${printAll}) /echo MaxTries ${${NewArrayName}[${i},${iMaxTries}]}		
-		
-		| get CheckFor
-		/if (${${ArrayName}[${i}].Find[/CheckFor|]}) {
-			/call argueString CheckFor| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iCheckFor}] ${c_argueString}
-		} else {
-      /varset ${NewArrayName}[${i},${iCheckFor}] -1
-		}
-		/if (${printAll}) /echo CheckFor ${${NewArrayName}[${i},${iCheckFor}]}		
-		
-		| get SpellDuration
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iDuration}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.Duration}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iDuration}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.Duration}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-			/varset	${NewArrayName}[${i},${iDuration}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Duration}			
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Disc]}) {
-      /varset	${NewArrayName}[${i},${iDuration}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Duration}
-    }
 
-		/if (${printAll}  || ${printMin}) /echo SpellDuration ${${NewArrayName}[${i},${iDuration}]}
-		
-		| get RecastTime
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iRecastTime}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.RecastTime}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iRecastTime}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].ReuseTime}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-			/varset	${NewArrayName}[${i},${iRecastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].RecastTime}			
-		} 
-		/if (${printAll}|| ${printMin}) /echo RecastTime ${${NewArrayName}[${i},${iRecastTime}]}
+		|we have optinal params, check to see which ones we need to overwrite
+		/if (!${SkipParams} && (${${ArrayName}[${i}].Find[/]} || ${isHealArray})) {
 
-		| get RecoveryTime
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iRecoveryTime}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.RecoveryTime}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iRecoveryTime}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.RecoveryTime}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-			/varset	${NewArrayName}[${i},${iRecoveryTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].RecoveryTime}			
-		} 
-		/if (${printAll}) /echo RecoveryTime ${${NewArrayName}[${i},${iRecoveryTime}]}
-		
-		| get MyCastTime
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iMyCastTime}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].CastTime}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iMyCastTime}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.MyCastTime}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-			/varset	${NewArrayName}[${i},${iMyCastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyCastTime}			
-		} 
-		/if (${printAll} || ${printMin}) /echo ${NewArrayName} ${i}  MyCastTime ${${NewArrayName}[${i},${iMyCastTime}]}
-		
-		| get MyRange
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/if (${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.AERange} > 0) {
-				/varset	${NewArrayName}[${i},${iMyRange}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.AERange}
-			} else {
-				/varset	${NewArrayName}[${i},${iMyRange}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.MyRange}
+			| get SpellGem
+			/if (${${ArrayName}[${i}].Find[/Gem|]}) {
+				/call argueString Gem| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iSpellGem}] ${c_argueString}
+			}
+			| get SubToRun
+			/if (${${ArrayName}[${i}].Find[/SubToRun|]}) {
+				/call argueString SubToRun| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iSubToRun}] ${c_argueString}
+			}
+			| get GiveUpTimer
+			/if (${${ArrayName}[${i}].Find[/GiveUpTimer|]}) {
+				/call argueString GiveUpTimer| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iGiveUpTimer}] ${c_argueString}
+			}
+			
+			| get MaxTries
+			/if (${${ArrayName}[${i}].Find[/MaxTries|]}) {
+				/call argueString MaxTries| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iMaxTries}] ${c_argueString}
+			}
+
+			| get CheckFor
+			/if (${${ArrayName}[${i}].Find[/CheckFor|]}) {
+				/call argueString CheckFor| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iCheckFor}] ${c_argueString}
+			}
+			
+			| get MinMana
+			/if (${${ArrayName}[${i}].Find[/MinMana|]}) {
+				/call argueString MinMana| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iMinMana}] ${c_argueString}
+			}
+			| get MaxMana
+			/if (${${ArrayName}[${i}].Find[/MaxMana|]}) {
+				/call argueString MaxMana| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iMaxMana}] ${c_argueString}
+			}
+
+			| get MinHP
+			/if (${${ArrayName}[${i}].Find[/MinHP|]}) {
+				/call argueString MinHP| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iMinHP}] ${c_argueString}
+			}
+
+			| get HealPct
+			/if (${isHealArray}) {
+				
+				/if (${${ArrayName}[${i}].Find[/HealPct|]}) {
+					/call argueString HealPct| "${${ArrayName}[${i}]}"
+					/varset ${NewArrayName}[${i},${iHealPct}] ${c_argueString}
+				} else {
+					/bc ${Me.Name} - ${errMsg} (Cannot find HealPct) : [${${ArrayName}[${i}]}]
+					/popup ${Me.Name} - ${errMsg} (Cannot find HealPct) : [${${ArrayName}[${i}]}] 
+					/beep					
+					/endmacro
+				}
 			}		
+			|/if (${printAll}) /echo HealPct ${${NewArrayName}[${i},${iHealPct}]}
+
+			| get Reagent
+			/if (${${ArrayName}[${i}].Find[/Reagent|]}) {
+				/call argueString Reagent| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iReagent}] ${c_argueString}
+			}
+			
+			| get NoBurn
+			/if (${${ArrayName}[${i}].Find[/NoBurn]}) {
+				/varset ${NewArrayName}[${i},${iNoBurn}] 1
+			}
+			
+			| get NoAggro
+			/if (${${ArrayName}[${i}].Find[/NoAggro]}) {
+				/varset ${NewArrayName}[${i},${iNoAggro}] 1
+			}
+			
+			| get Mode
+			/if (${${ArrayName}[${i}].Find[/Mode|]}) {
+				/call argueString Mode "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iMode}] ${c_argueString}
+			}
+			
+			| get Rotate
+			/if (${${ArrayName}[${i}].Find[/Rotate]}) /varset ${NewArrayName}[${i},${iRotate}] 1
+			
+
+			| get Delay
+			/if (${${ArrayName}[${i}].Find[/Delay|]}) {
+				/call argueString Delay| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iDelay}] ${c_argueString}
+			}
+			
+			| get GiftOfMana
+			/if (${${ArrayName}[${i}].Find[/GoM]}) /varset ${NewArrayName}[${i},${iGiftOfMana}] 1
+
+			| get iPctAggro
+			/if (${${ArrayName}[${i}].Find[/PctAggro|]}) {
+				/call argueString PctAggro| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iPctAggro}] ${c_argueString}
+			}
+
+			| get iZone - only for curing
+			/if (${${ArrayName}[${i}].Find[/Zone|]}) {
+				/call argueString Zone| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iZone}] ${c_argueString}
+			} 
+			| get iMinSick - only for curing
+			/if (${${ArrayName}[${i}].Find[/MinSick|]}) {
+				/call argueString MinSick| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iMinSick}] ${c_argueString}
+			}
+			
+			| get iAllowSpellSwap -- used in DoT casting to allow casters to shuffle a large number of DoTs
+			| DoTs defined with /AllowSpellSwap immediately de-mem after casting so another spell can be automatically memed in it's place
+			/if (${${ArrayName}[${i}].Find[/AllowSpellSwap]}) {
+				/varset ${NewArrayName}[${i},${iAllowSpellSwap}] 1
+			}
+			| get iNoEarlyRecast -- used for DoTs like Splurt/Splort that you want to wear off before recasting
+			/if (${${ArrayName}[${i}].Find[/NoEarlyRecast]}) {
+				/varset ${NewArrayName}[${i},${iNoEarlyRecast}] 1
+			}
+
+			| get NoStack -- used for DoTs/Debuffs that cannot be used form two people on 1 NPC at the same time. (DoTs with a debuff)
+			| Note: this was created for necromancer / druid epics on Project Lazarus.
+			/if (${${ArrayName}[${i}].Find[/NoStack]}) {
+				/varset ${NewArrayName}[${i},${iNoStack}] 1
+			}
+
+			| get TriggerSpell -- used for DoTs only. 
+			| Example: Main=Dread Pyre/TriggerSpell|Funeral Pyre of Kelador
+			| Dread Pyre will cast "Dread Pyre" AND "Funeral Pyre of Keldador" at the same time (custom spells)
+			| TriggerSpell check allows E3 to re-cast the spell "Dread Pyre" if either of these two DoTs are missing from the NPC.
+			/if (${${ArrayName}[${i}].Find[/TriggerSpell|]}) {
+				/call argueString TriggerSpell| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iTriggerSpell}] ${c_argueString}
+			}
+			
+
+			| get iIfs - conditionals used in various places
+			/if (${${ArrayName}[${i}].Find[/Ifs|]}) {
+				/call argueString Ifs| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iIfs}] ${Ini[${Character_Ini},Ifs,${c_argueString},NULL,noparse]}
+			| we kind of need to print here instead of like everything else :P
+				/if (${printAll}) /echo Ifs ${c_argueString}
+			}
+
+			| get MinEnd
+			/if (${${ArrayName}[${i}].Find[/MinEnd|]}) {
+				/call argueString MinEnd| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iMinEnd}] ${c_argueString}
+			}
+
+		} 
+	
+
+		|Fill out information based off Item/AA/Spell/Disc
+		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
+			|ITEM INFORMATION
+			|Instead of calling FindItem 12 times, we call it twice and get a direct reference to the item in question
+
+			| ${Me.Inventory[23].Item[7].Spell.TargetType}
+			/varset invSlot ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].ItemSlot}
+			/varset bagSlot ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].ItemSlot2}
+
+			/if (${bagSlot}==-1) {
+				|/echo root item: id:${invSlot} :${${ArrayName}[${i}].Arg[1,/]}
+				|Means this is not in a bag and in the root inventory
+				/varset	${NewArrayName}[${i},${iTargetType}] ${Me.Inventory[${invSlot}].Spell.TargetType}
+				/varset	${NewArrayName}[${i},${iDuration}] ${Me.Inventory[${invSlot}].Spell.Duration}
+				/varset	${NewArrayName}[${i},${iRecastTime}] ${Me.Inventory[${invSlot}].Spell.RecastTime}
+				/varset	${NewArrayName}[${i},${iRecoveryTime}] ${Me.Inventory[${invSlot}].Spell.RecoveryTime}
+				/varset	${NewArrayName}[${i},${iMyCastTime}] ${Me.Inventory[${invSlot}].CastTime}
+				/if (${Me.Inventory[${invSlot}].Spell.AERange} > 0) {
+					/varset	${NewArrayName}[${i},${iMyRange}] ${Me.Inventory[${invSlot}].Spell.AERange}
+				} else {
+					/varset	${NewArrayName}[${i},${iMyRange}] ${Me.Inventory[${invSlot}].Spell.MyRange}
+				}
+				/if (${Me.Inventory[${invSlot}].EffectType.Equal[Click Worn]}) {
+					/varset	${NewArrayName}[${i},${iItemMustEquip}] ${Me.Inventory[${invSlot}].WornSlot[1].Name}
+				}
+				/varset	${NewArrayName}[${i},${iSpellName}] ${Me.Inventory[${invSlot}].Spell}
+				/varset	${NewArrayName}[${i},${iSpellID}] ${Me.Inventory[${invSlot}].Spell.ID}
+				/varset	${NewArrayName}[${i},${iCastID}] ${Me.Inventory[${invSlot}].ID}
+				/varset	${NewArrayName}[${i},${iSpellType}] ${Me.Inventory[${invSlot}].Spell.SpellType}
+
+			} else {
+				|1 index vs 0 index
+				/varcalc bagSlot ${bagSlot}+1
+				|/echo bag item:id id:${invSlot},${bagSlot}:${${ArrayName}[${i}].Arg[1,/]}
+				/varset	${NewArrayName}[${i},${iTargetType}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.TargetType}
+				/varset	${NewArrayName}[${i},${iDuration}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.Duration}
+				/varset	${NewArrayName}[${i},${iRecastTime}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.RecastTime}
+				/varset	${NewArrayName}[${i},${iRecoveryTime}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.RecoveryTime}
+				/varset	${NewArrayName}[${i},${iMyCastTime}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].CastTime}
+				/if (${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.AERange} > 0) {
+					/varset	${NewArrayName}[${i},${iMyRange}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.AERange}
+				} else {
+					/varset	${NewArrayName}[${i},${iMyRange}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.MyRange}
+				}
+				/if (${Me.Inventory[${invSlot}].Item[${bagSlot}].EffectType.Equal[Click Worn]}) {
+					/varset	${NewArrayName}[${i},${iItemMustEquip}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].WornSlot[1].Name}
+				}
+				/varset	${NewArrayName}[${i},${iSpellName}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell}
+				/varset	${NewArrayName}[${i},${iSpellID}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.ID}
+				/varset	${NewArrayName}[${i},${iCastID}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].ID}
+				/varset	${NewArrayName}[${i},${iSpellType}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.SpellType}
+			}
+
 		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
+			|AA INFORMATION
+			/varset	${NewArrayName}[${i},${iTargetType}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.TargetType}
+			/varset	${NewArrayName}[${i},${iDuration}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.Duration}
+			/varset	${NewArrayName}[${i},${iRecastTime}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].ReuseTime}
+			/varset	${NewArrayName}[${i},${iRecoveryTime}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.RecoveryTime}
+			/varset	${NewArrayName}[${i},${iMyCastTime}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.MyCastTime}
 			/if (${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.AERange} > 0) {
 				/varset	${NewArrayName}[${i},${iMyRange}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.AERange}
 			} else {
 				/varset	${NewArrayName}[${i},${iMyRange}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.MyRange}
-			}		
+			}
+			/varset	${NewArrayName}[${i},${iSpellName}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell}
+			/varset	${NewArrayName}[${i},${iSpellID}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.ID}
+			/varset	${NewArrayName}[${i},${iCastID}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].ID}
+			/varset	${NewArrayName}[${i},${iSpellType}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.SpellType}	
+		
 		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
+			|SPELL INFORMATION
+			/varset	${NewArrayName}[${i},${iTargetType}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].TargetType}
+			/varset	${NewArrayName}[${i},${iDuration}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Duration}	
+			/varset	${NewArrayName}[${i},${iRecastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].RecastTime}	
+			/varset	${NewArrayName}[${i},${iRecoveryTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].RecoveryTime}	
+			/varset	${NewArrayName}[${i},${iMyCastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyCastTime}	
 			/if (${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange} > 0 && ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyRange} == 0) {
 				/varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange}
 			} else {
 				/varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyRange}
-			}
-    } else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-      /if (${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange} > 0) {
-        /varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange}
-      } else {
-        /varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyRange}
-      }
-    } else /if (${${NewArrayName}[${i},${iCastType}].Equal[Disc]}) {
-      /if (${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange} > 0) {
-        /varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange}
-      } else {
-        /varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyRange}
-      }
-    }
-  /if (${printAll}) /echo MyRange ${${NewArrayName}[${i},${iMyRange}]}
-		
-		| get Mana
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) /varset ${NewArrayName}[${i},${iMana}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Mana}
-		/if (${printAll}) /echo Mana ${${NewArrayName}[${i},${iMana}]}
-		
-		| get MinMana
-		/if (${${ArrayName}[${i}].Find[/MinMana|]}) {
-			/call argueString MinMana| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iMinMana}] ${c_argueString}
-		}
-		/if (${printAll}) /echo MinMana ${${NewArrayName}[${i},${iMinMana}]}	
-
-		| get MaxMana
-		/if (${${ArrayName}[${i}].Find[/MaxMana|]}) {
-			/call argueString MaxMana| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iMaxMana}] ${c_argueString}
-		} else {
-			/varset ${NewArrayName}[${i},${iMaxMana}] 100
-		}
-		/if (${printAll}) /echo MaxMana ${${NewArrayName}[${i},${iMaxMana}]}
-
-		| get MinHP
-		/if (${${ArrayName}[${i}].Find[/MinHP|]}) {
-			/call argueString MinHP| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iMinHP}] ${c_argueString}
-		} else {
-			/varset ${NewArrayName}[${i},${iMinHP}] 70
-		}
-		/if (${printAll}) /echo MinHP ${${NewArrayName}[${i},${iMinHP}]}	
-
-		| get HealPct
-		/if (${Select[${ArrayName},tankHeals,importantHeals,allHeals,hotSpells,groupHeals,lifeSupport,petHeal,petHeals,lifeTaps,xtargetHeals]}) {
-			/if (${${ArrayName}[${i}].Find[/HealPct|]}) {
-				/call argueString HealPct| "${${ArrayName}[${i}]}"
-				/varset ${NewArrayName}[${i},${iHealPct}] ${c_argueString}
-			} else {
-				/bc ${Me.Name} - ${errMsg} (Cannot find HealPct) : [${${ArrayName}[${i}]}]
-				/popup ${Me.Name} - ${errMsg} (Cannot find HealPct) : [${${ArrayName}[${i}]}] 
-				/beep					
-				/endmacro
-			}
-		}		
-		|/if (${printAll}) /echo HealPct ${${NewArrayName}[${i},${iHealPct}]}
-		
-		| get Reagent
-		/if (${${ArrayName}[${i}].Find[/Reagent|]}) {
-			/call argueString Reagent| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iReagent}] ${c_argueString}
-		}
-		/if (${printAll}) /echo Reagent ${${NewArrayName}[${i},${iReagent}]}
-
-		| get ItemMustEquip
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]} && ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].EffectType.Equal[Click Worn]}) {
-			/varset	${NewArrayName}[${i},${iItemMustEquip}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].WornSlot[1].Name}
-		}
-		/if (${printAll}) /echo ItemMustEquip ${${NewArrayName}[${i},${iItemMustEquip}]}
-
-		| get SpellName
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iSpellName}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iSpellName}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
+			}			
+			/varset ${NewArrayName}[${i},${iMana}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Mana}
 			/varset	${NewArrayName}[${i},${iSpellName}] ${Spell[${${NewArrayName}[${i},${iCastName}]}]}
-    } else /if (${${NewArrayName}[${i},${iCastType}].Equal[Disc]}) {
-      /varset	${NewArrayName}[${i},${iSpellName}] ${Spell[${${NewArrayName}[${i},${iCastName}]}]}
-    }
-		/if (${printAll}) /echo SpellName ${${NewArrayName}[${i},${iSpellName}]}
-    | get SpellID
-      /if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-        /varset	${NewArrayName}[${i},${iSpellID}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.ID}
-      } else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-        /varset	${NewArrayName}[${i},${iSpellID}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.ID}
-      } else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-        /varset	${NewArrayName}[${i},${iSpellID}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].ID}
-      } else /if (${${NewArrayName}[${i},${iCastType}].Equal[Disc]}) {
-        /varset	${NewArrayName}[${i},${iSpellID}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].ID}
-      }
-      /if (${printAll}) /echo SpellID ${${NewArrayName}[${i},${iSpellID}]}
-		
-		| get NoBurn
-		/if (${${ArrayName}[${i}].Find[/NoBurn]}) {
-			/varset ${NewArrayName}[${i},${iNoBurn}] 1
-		}
-		/if (${printAll}) /echo NoBurn ${${NewArrayName}[${i},${iNoBurn}]}
-
-		| get NoAggro
-		/if (${${ArrayName}[${i}].Find[/NoAggro]}) {
-			/varset ${NewArrayName}[${i},${iNoAggro}] 1
-		}
-		/if (${printAll}) /echo NoAggro ${${NewArrayName}[${i},${iNoAggro}]}		
-
-		| get Mode
-		/if (${${ArrayName}[${i}].Find[/Mode|]}) {
-			/call argueString Mode "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iMode}] ${c_argueString}
-		}
-		/if (${printAll}) /echo Mode ${${NewArrayName}[${i},${iMode}]}
-
-		| get Rotate
-		/if (${${ArrayName}[${i}].Find[/Rotate]}) /varset ${NewArrayName}[${i},${iRotate}] 1
-		/if (${printAll}) /echo Rotate ${${NewArrayName}[${i},${iRotate}]}
-
-		| get Delay
-		/if (${${ArrayName}[${i}].Find[/Delay|]}) {
-			/call argueString Delay| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iDelay}] ${c_argueString}
-		}
-		/if (${printAll} || ${printMin}) /echo Delay ${${NewArrayName}[${i},${iDelay}]}		
-
-		| get CastID
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iCastID}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].ID}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iCastID}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].ID}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
+			/varset	${NewArrayName}[${i},${iSpellID}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].ID}
 			/varset	${NewArrayName}[${i},${iCastID}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].ID}
-    } else /if (${${NewArrayName}[${i},${iCastType}].Equal[Disc]}) {
-      /varset	${NewArrayName}[${i},${iCastID}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].ID}
-    }
-		/if (${printAll}) /echo iCastID ${${NewArrayName}[${i},${iCastID}]}
-
-    | get CheckForID
-    /if (${Bool[${AltAbility[${${NewArrayName}[${i},${iCheckFor}]}].Spell}]}) {
-      /varset ${NewArrayName}[${i},${iCheckForID}] ${AltAbility[${${NewArrayName}[${i},${iCheckFor}]}].Spell.ID}
-    } else /if (${Bool[${Spell[${${NewArrayName}[${i},${iCheckFor}]}].ID}]}) {
-      /varset ${NewArrayName}[${i},${iCheckForID}] ${Spell[${${NewArrayName}[${i},${iCheckFor}]}].ID}
-    } else {
-      /varset ${NewArrayName}[${i},${iCheckForID}] -1
-    }
-    /if (${printAll}) /echo ${${NewArrayName}[${i},${iCastName}]} ${${NewArrayName}[${i},${iCheckFor}]} iCheckForID ${${NewArrayName}[${i},${iCheckForID}]}
-
-		| get MinEnd
-		/if (${${ArrayName}[${i}].Find[/MinEnd|]}) {
-			/call argueString MinEnd| "${${ArrayName}[${i}]}"
-			/varset ${NewArrayName}[${i},${iMinEnd}] ${c_argueString}
-		} else {
-		  |default to casting until out of endurance
-      /varset ${NewArrayName}[${i},${iMinEnd}] 0
+			/varset	${NewArrayName}[${i},${iSpellType}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].SpellType}
+		
+		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Disc]}) {
+			|DISC INFORMATION
+			/varset	${NewArrayName}[${i},${iDuration}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Duration}
+			/if (${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange} > 0) {
+				/varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].AERange}
+			} else {
+				/varset	${NewArrayName}[${i},${iMyRange}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyRange}
+			}
+			/varset	${NewArrayName}[${i},${iSpellName}] ${Spell[${${NewArrayName}[${i},${iCastName}]}]}
+			/varset	${NewArrayName}[${i},${iSpellID}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].ID}
+			/varset	${NewArrayName}[${i},${iCastID}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].ID}
+		
+		
 		}
-		/if (${printAll}) /echo MinEnd ${${NewArrayName}[${i},${iMinEnd}]}
 
-		| get SpellType
-		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
-			/varset	${NewArrayName}[${i},${iSpellType}] ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].Spell.SpellType}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[AA]}) {
-			/varset	${NewArrayName}[${i},${iSpellType}] ${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell.SpellType}
-		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
-			/varset	${NewArrayName}[${i},${iSpellType}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].SpellType}		
-		} 
-		/if (${printAll}) /echo SpellType ${${NewArrayName}[${i},${iSpellType}]}
+		| get CheckForID
+		/if (${Bool[${AltAbility[${${NewArrayName}[${i},${iCheckFor}]}].Spell}]}) {
+			/varset ${NewArrayName}[${i},${iCheckForID}] ${AltAbility[${${NewArrayName}[${i},${iCheckFor}]}].Spell.ID}
+		} else /if (${Bool[${Spell[${${NewArrayName}[${i},${iCheckFor}]}].ID}]}) {
+			/varset ${NewArrayName}[${i},${iCheckForID}] ${Spell[${${NewArrayName}[${i},${iCheckFor}]}].ID}
+		} else {
+			/varset ${NewArrayName}[${i},${iCheckForID}] -1
+		}
 
-		| get CastTarget
-		/if (${Select[${ArrayName},BotBuffs,PetBuffs,CombatBuffs,cureTargets]}) /varset ${NewArrayName}[${i},${iCastTarget}] ${${ArrayName}[${i}].Arg[2,/]}
-		/if (${printAll}) /echo CastTarget ${${NewArrayName}[${i},${iCastTarget}]}
-
-    | get GiftOfMana
-    /if (${${ArrayName}[${i}].Find[/GoM]}) /varset ${NewArrayName}[${i},${iGiftOfMana}] 1
-    /if (${printAll}) /echo GiftOfMana ${${NewArrayName}[${i},${iGiftOfMana}]}
-
-    | get iPctAggro
-    /if (${${ArrayName}[${i}].Find[/PctAggro|]}) {
-      /call argueString PctAggro| "${${ArrayName}[${i}]}"
-      /varset ${NewArrayName}[${i},${iPctAggro}] ${c_argueString}
-    } else {
-      |default PctAggro to 0, cast even when aggro target
-      /varset	${NewArrayName}[${i},${iPctAggro}] 0
-    }
-    /if (${printAll}) /echo PctAggro ${${NewArrayName}[${i},${iPctAggro}]}
-
-    | get iZone - only for curing
-    /if (${${ArrayName}[${i}].Find[/Zone|]}) {
-      /call argueString Zone| "${${ArrayName}[${i}]}"
-      /varset ${NewArrayName}[${i},${iZone}] ${c_argueString}
-    } else {
-      |default to All zones
-      /varset	${NewArrayName}[${i},${iZone}] All
-    }
-    /if (${printAll}) /echo Zone ${${NewArrayName}[${i},${iZone}]}
-
-  | get iMinSick - only for curing
-    /if (${${ArrayName}[${i}].Find[/MinSick|]}) {
-      /call argueString MinSick| "${${ArrayName}[${i}]}"
-      /varset ${NewArrayName}[${i},${iMinSick}] ${c_argueString}
-    } else {
-      /varset	${NewArrayName}[${i},${iMinSick}] 0
-    }
-    /if (${printAll}) /echo Zone ${${NewArrayName}[${i},${iMinSick}]}
-
-	| get iAllowSpellSwap -- used in DoT casting to allow casters to shuffle a large number of DoTs
-	| DoTs defined with /AllowSpellSwap immediately de-mem after casting so another spell can be automatically memed in it's place
-	/if (${${ArrayName}[${i}].Find[/AllowSpellSwap]}) {
-		/varset ${NewArrayName}[${i},${iAllowSpellSwap}] 1
-	} else {
-		/varset ${NewArrayName}[${i},${iAllowSpellSwap}] 0
-	}
-	/if (${printAll}) /echo AllowSpellSwap ${${NewArrayName}[${i},${iAllowSpellSwap}]}		
-
-	| get iNoEarlyRecast -- used for DoTs like Splurt/Splort that you want to wear off before recasting
-	/if (${${ArrayName}[${i}].Find[/NoEarlyRecast]}) {
-		/varset ${NewArrayName}[${i},${iNoEarlyRecast}] 1
-	} else {
-		/varset ${NewArrayName}[${i},${iNoEarlyRecast}] 0
-	}
-	/if (${printAll}) /echo NoEarlyRecast ${${NewArrayName}[${i},${iNoEarlyRecast}]}		
-
-	| get NoStack -- used for DoTs/Debuffs that cannot be used form two people on 1 NPC at the same time. (DoTs with a debuff)
-	| Note: this was created for necromancer / druid epics on Project Lazarus.
-	/if (${${ArrayName}[${i}].Find[/NoStack]}) {
-		/varset ${NewArrayName}[${i},${iNoStack}] 1
-	} else {
-		/varset ${NewArrayName}[${i},${iNoStack}] 0
-	}
-	/if (${printAll}) /echo NoStack ${${NewArrayName}[${i},${iNoStack}]}	
-
-	| get TriggerSpell -- used for DoTs only. 
-	| Example: Main=Dread Pyre/TriggerSpell|Funeral Pyre of Kelador
-	| Dread Pyre will cast "Dread Pyre" AND "Funeral Pyre of Keldador" at the same time (custom spells)
-	| TriggerSpell check allows E3 to re-cast the spell "Dread Pyre" if either of these two DoTs are missing from the NPC.
-    /if (${${ArrayName}[${i}].Find[/TriggerSpell|]}) {
-      /call argueString TriggerSpell| "${${ArrayName}[${i}]}"
-      /varset ${NewArrayName}[${i},${iTriggerSpell}] ${c_argueString}
-    } else {
-      /varset	${NewArrayName}[${i},${iTriggerSpell}] 0
-    }
-    /if (${printAll}) /echo TriggerSpell ${${NewArrayName}[${i},${iTriggerSpell}]}
-
-    | get iIfs - conditionals used in various places
-    /if (${${ArrayName}[${i}].Find[/Ifs|]}) {
-        /call argueString Ifs| "${${ArrayName}[${i}]}"
-        /varset ${NewArrayName}[${i},${iIfs}] ${Ini[${Character_Ini},Ifs,${c_argueString},NULL,noparse]}
-        | we kind of need to print here instead of like everything else :P
-        /if (${printAll}) /echo Ifs ${c_argueString}
-    } else {
-        /varset ${NewArrayName}[${i},${iIfs}] TRUE
-        /if (${printAll}) /echo Ifs TRUE
-    }
-    |default casting while invis to 0 which impies no casting while invis
-    /varset	${NewArrayName}[${i},${iCastInvis}] 0
-		/if (${printAll}) /echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		/next i
+	
+		|Print out debug information if requsted
+		/if (${printAll} || ${printMin}) {
+	
+			/if (${printAll} || ${printMin}) /echo CastName ${${NewArrayName}[${i},${iCastName}]}
+			/if (${printAll}  || ${printMin}) /echo CastType ${${NewArrayName}[${i},${iCastType}]}
+			/if (${printAll}) /echo TargetType ${${NewArrayName}[${i},${iTargetType}]}
+			/if (${printAll}|| ${printMin}) /echo SpellGem ${${NewArrayName}[${i},${iSpellGem}]}
+			/if (${printAll}) /echo SubToRun ${${NewArrayName}[${i},${iSubToRun}]}
+			/if (${printAll}) /echo GiveUpTimer ${${NewArrayName}[${i},${iGiveUpTimer}]}
+			/if (${printAll}) /echo MaxTries ${${NewArrayName}[${i},${iMaxTries}]}
+			/if (${printAll}) /echo CheckFor ${${NewArrayName}[${i},${iCheckFor}]}
+			/if (${printAll}) /echo MinMana ${${NewArrayName}[${i},${iMinMana}]}
+			/if (${printAll}) /echo MaxMana ${${NewArrayName}[${i},${iMaxMana}]}
+			/if (${printAll}) /echo MinHP ${${NewArrayName}[${i},${iMinHP}]}
+			/if (${printAll}) /echo Reagent ${${NewArrayName}[${i},${iReagent}]}
+			/if (${printAll}) /echo NoBurn ${${NewArrayName}[${i},${iNoBurn}]}
+			/if (${printAll}) /echo NoAggro ${${NewArrayName}[${i},${iNoAggro}]}
+			/if (${printAll}) /echo Mode ${${NewArrayName}[${i},${iMode}]}	
+			/if (${printAll}) /echo Rotate ${${NewArrayName}[${i},${iRotate}]}	
+			/if (${printAll}) /echo Delay ${${NewArrayName}[${i},${iDelay}]}	
+			/if (${printAll}) /echo GiftOfMana ${${NewArrayName}[${i},${iGiftOfMana}]}
+			/if (${printAll}) /echo PctAggro ${${NewArrayName}[${i},${iPctAggro}]}
+			/if (${printAll}) /echo Zone ${${NewArrayName}[${i},${iZone}]}
+			/if (${printAll}) /echo Zone ${${NewArrayName}[${i},${iMinSick}]}
+			/if (${printAll}) /echo AllowSpellSwap ${${NewArrayName}[${i},${iAllowSpellSwap}]}	
+			/if (${printAll}) /echo NoEarlyRecast ${${NewArrayName}[${i},${iNoEarlyRecast}]}
+			/if (${printAll}) /echo NoStack ${${NewArrayName}[${i},${iNoStack}]}
+			/if (${printAll}) /echo TriggerSpell ${${NewArrayName}[${i},${iTriggerSpell}]}
+			|This print is an oddball, had to leave it back in the setting of the variable
+			|as it does some argument parsing to get it and the result is
+			/if (${printAll}) {
+				/if (${${NewArrayName}[${i},${iIfs}]}) {
+					/echo Ifs always TRUE
+				} 	
+			}
+			/if (${printAll}) /echo MinEnd ${${NewArrayName}[${i},${iMinEnd}]}
+			/if (${printAll}  || ${printMin}) /echo SpellDuration ${${NewArrayName}[${i},${iDuration}]}
+			/if (${printAll}|| ${printMin}) /echo RecastTime ${${NewArrayName}[${i},${iRecastTime}]}
+			/if (${printAll}) /echo RecoveryTime ${${NewArrayName}[${i},${iRecoveryTime}]}
+			/if (${printAll} || ${printMin}) /echo ${NewArrayName} ${i}  MyCastTime ${${NewArrayName}[${i},${iMyCastTime}]}
+			/if (${printAll}) /echo MyRange ${${NewArrayName}[${i},${iMyRange}]}
+			/if (${printAll}) /echo Mana ${${NewArrayName}[${i},${iMana}]}
+			/if (${printAll}) /echo ItemMustEquip ${${NewArrayName}[${i},${iItemMustEquip}]}
+			/if (${printAll}) /echo SpellName ${${NewArrayName}[${i},${iSpellName}]}
+			/if (${printAll}) /echo SpellID ${${NewArrayName}[${i},${iSpellID}]}
+			/if (${printAll}) /echo iCastID ${${NewArrayName}[${i},${iCastID}]}
+			/if (${printAll}) /echo ${${NewArrayName}[${i},${iCastName}]} ${${NewArrayName}[${i},${iCheckFor}]} iCheckForID ${${NewArrayName}[${i},${iCheckForID}]}
+			/if (${printAll}) /echo SpellType ${${NewArrayName}[${i},${iSpellType}]}
+			/if (${printAll}) /echo CastTarget ${${NewArrayName}[${i},${iCastTarget}]}
+			/if (${printAll}) /echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+								
+		}
+		
+	/next i
 	|/deletevar ${ArrayName}
 /RETURN	${NewArrayName}
 

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -339,7 +339,10 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 		
 	/next i
 
-	/declare isHealArray bool local ${Select[${ArrayName},tankHeals,importantHeals,allHeals,hotSpells,groupHeals,lifeSupport,petHeal,petHeals,lifeTaps,xtargetHeals]
+	/declare isHealArray bool local ${Select[${ArrayName},tankHeals,importantHeals,allHeals,hotSpells,groupHeals,lifeSupport,petHeal,petHeals,lifeTaps,xtargetHeals]}
+	|/echo checking array name: ${ArrayName}
+	|/echo isHealArray: ${isHealArray}
+	|/echo Skip Params: ${SkipParams}
 	/declare isCastTargetArray bool local ${Select[${ArrayName},BotBuffs,PetBuffs,CombatBuffs,cureTargets]}
 	/for i 1 to ${${ArrayName}.Size}
 		| get SpellName
@@ -441,8 +444,7 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 					/endmacro
 				}
 			}		
-			|/if (${printAll}) /echo HealPct ${${NewArrayName}[${i},${iHealPct}]}
-
+		
 			| get Reagent
 			/if (${${ArrayName}[${i}].Find[/Reagent|]}) {
 				/call argueString Reagent| "${${ArrayName}[${i}]}"
@@ -652,12 +654,13 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 
 	
 		|Print out debug information if requsted
-		/if (${printAll} || ${printMin}) {
+		/if (${printAll} || ${printMin} || ${isHealArray}) {
 	
 			/if (${printAll} || ${printMin}) /echo CastName ${${NewArrayName}[${i},${iCastName}]}
 			/if (${printAll}  || ${printMin}) /echo CastType ${${NewArrayName}[${i},${iCastType}]}
 			/if (${printAll}) /echo TargetType ${${NewArrayName}[${i},${iTargetType}]}
 			/if (${printAll}|| ${printMin}) /echo SpellGem ${${NewArrayName}[${i},${iSpellGem}]}
+			/if (${printAll}|| ${printMin}) /echo HealPct ${${NewArrayName}[${i},${iHealPct}]}
 			/if (${printAll}) /echo SubToRun ${${NewArrayName}[${i},${iSubToRun}]}
 			/if (${printAll}) /echo GiveUpTimer ${${NewArrayName}[${i},${iGiveUpTimer}]}
 			/if (${printAll}) /echo MaxTries ${${NewArrayName}[${i},${iMaxTries}]}

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -27,6 +27,7 @@ SUB Main(modeSelect)
 /if (${Debug}) /echo |- MainLoop ==>
 		/varset ActionTaken FALSE
     /call check_ResistCounters
+    /call check_ItemDeleteSummoned
 		/call check_Active
 		/call check_Idle
     /call check_autoTribute

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -26,9 +26,8 @@ SUB Main(modeSelect)
 :MainLoop
 /if (${Debug}) /echo |- MainLoop ==>
 		/varset ActionTaken FALSE
-    /call check_ResistCounters
-    /call check_ItemDeleteSummoned
-		/call check_Active
+    /call check_Basics
+ 		/call check_Active
 		/call check_Idle
     /call check_autoTribute
     /if (${currentZone} != ${Zone.ID})  /call check_Zone


### PR DESCRIPTION
Changelog includes these notes as well:

--------- Fixed:
	- When using Gimme to your mage for Mod Shards, characters will no longer will disconnect if they are in the middle of a cast. 
	***NOTE*** If you use /itemnotify <item> leftmouseup while casting, your toon will DC! Avoid this with customizations!
	- Gimme large shard delete feature now works with all versions of Mod Shards 
	- Self Mod Shard for Supply mage now works
	- Fix for /GoM on spells in the nuke section. This should work properly now.
	- Gimme will now recast on fizzles and uses BC tells instead of /tell for group members.
	- Gimme will use e3_Cast now instead of raw /cast function
--------- Changed:
	- Optimizations for BuildSpellArray. Originally BuildSpellArray was for one time builds for spell casts at initial startup and the results saved and thus speed wasn't an important consideration. 
		> However the new method castSimpleSpellArray uses BuildSpellArray and thus a passthrough was neeeded. Entire method was reworked and reorganized. Over 140+ conditionals/checks/method calls removed in most circumstances.
	- /ClickIt will now dismount and call /stopcast before *IF* you are in the middle of a spell cast before clicking. This helps prevent crashes related to casting-while-initiating a zone
	- /SwarmPets changes:
		> Swarm Pets now trigger significantly quicker than before
		> Necromancer AA 'Rise of Bones' is correctly added to the swarpPets array when you own the AA
		> Necromancer Epic 1.5 / 2.0 are both now included as a swarm pet
		> Graverobber's Icon from HCUR is now included as a swarm pet
		> Necromancer "Wake the Dead" has been REMOVED from /SwarmPets because it is known to cause zone crashes. You can still include it in other parts of your INI like Burns at your own risk.
	- Old #inst add code has been completely removed.
--------- Added:
	- New Magician feature for gearing group pets automatically (details below)
	- A timer on nukes was created to prevent an item from being 'attempted' to be cast mutiple times even if it was on cooldown. 
		> E3 would cast the item, then loop back around and it would see the item as a valid cast again as "cooldown" would not be set yet. 
		> Now a 1 second timer is created for any item based nuke to give time for the client to get the updated value and start the items cooldown.  
		> This probably should be done in other areas but at the time I was testing Molten Orb from the mage.
	- Players can now send the expedition leader a tell saying "dzadd" to automatically get invites. 
	***EXAMPLE*** "/t Ewiclip dzadd" (single player) or "/bcaa //t Ewiclip dzadd" (all eqbcs players)
	- Necromancer "Orb of Shadows" and "Orb of Souls" will now automatically cast on Tank Heals and XTarget Heal if the target is below 90% HP immediately following a heal. This can be toggled on/off inside the Heal Section of the INI. This feature is ON by default. 
	***NOTE*** E3 WILL NOT BEEP IF YOU'RE OUT OF ORBS. It is completely up to you to ensure your healers have orbs in their inventory if you'd like to use this feature. 
	- castSimpleSpell "spellName" "targetid"
	> This will use e3 Cast but is far simpler to use. Used for spells that are non combat related and you don't expect to fail
		Stop using /casting please :)
	- notifyViaBCTell  ${ChatSender} "Message"
		> this will try and use /bct if the ChatSender is in your group of bots, else it uses /tell
	- check_Basics
		>This is added for a check method you want to work across all toons, to limit the pollution of the Adv.ini 

	- PrivateCode.inc created and included for everyone. This is a place to include your personal customizations that you don't want to lose with future updates. 
	***We will not provide future updates to this file. **NOTE** be sure to not overwrite your file with a future "BLANK" file***
	***if you contribute to the github repository you can use this command to prevent git from uploading your private code ***
	*** 	> git update-index --skip-worktree e3_PrivateCode.inc ****
	
--------- Pet Arming Changes:
	- New Arm Pets feature which opens up new commands to the mage in your group.
		> From the non-mage send a /tell to your mage
		-> "arm pets", 
		-> "arm pets fire" , 
		-> "arm pets ice", 
		-> "arm pets 2dispel", 
		-> "arm pets default <character>", 
		-> "arm pets ice <character>", 
		-> "arm pets fire <character>" 
		-> "arm pets 2dispel <character>"
	
	This will equip all the members of your group (if you don't specify character) with the spectral plate/heirlooms + configured loadouts for your class.
	***NOTE*** a free bag space is required from your mage. 

	- If you have any particular loadouts that you want to see, please let me know so I can include them. 
		> Currently:
		-> Mage/Enc/Nec default is Slow/Dispell.  SK/Druid default is Dispell/Mala, Everyone else is also Dispell/Mala. 
		-> Mage/Enc/Nec fire is Fire/Fire, Sk/Druid is Fire/Mala
		-> Mage/Enc/Nec ice is ice/ice, SK/Druid is ice/mala.
		-> Mage/Enc/Nec 2dispel is dispel/dispel, SK/Druid is dispel/dispel.

