### PR TITLE
Enhancement/arm pet

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1525,7 +1525,8 @@ Sub basics_Setup
 	/declare medBreak_Hold bool outer FALSE
 	/declare medOn_combatBreak bool outer FALSE
 	/declare autoMedChar bool outer FALSE
-	/declare medbreak_Popup_Timer timer outer
+  /declare anchorChar string outer 
+  /declare medbreak_Popup_Timer timer outer
 	/declare clickitRandomDelay int outer 7
 
 	/if (${Ini[${genSettings_Ini},ExpGroup,NoKS_WeaponSet].Length}) 		/call iniToVarV "${genSettings_Ini},ExpGroup,NoKS_WeaponSet" NoKSWeaponSet string outer
@@ -1540,8 +1541,9 @@ Sub basics_Setup
 	/if (${Ini[${genSettings_Ini},General,Leash Length].Length} && ${Int[${Ini[${genSettings_Ini},General,Leash Length]}]}) /call iniToVarV "${genSettings_Ini},General,Leash Length" LeashLength int outer
 	/if (${Ini[${genSettings_Ini},General,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${genSettings_Ini},General,End MedBreak in Combat(On/Off)" medOn_combatBreak bool outer
 	/if (${Ini[${genSettings_Ini},General,AutoMedBreak PctMana].Length}) /call iniToVarV "${genSettings_Ini},General,AutoMedBreak PctMana" autoMedPctMana int outer
-  	/if (${Ini[${Character_Ini},Misc,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" medOn_combatBreakChar bool outer
+  /if (${Ini[${Character_Ini},Misc,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" medOn_combatBreakChar bool outer
 	/if (${Ini[${Character_Ini},Misc,AutoMedBreak (On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,AutoMedBreak (On/Off)" autoMedChar bool outer
+  /if (${Ini[${Character_Ini},Misc,Anchor (Char to Anchor to)].Length}) /call iniToVarV "${Character_Ini},Misc,Anchor (Char to Anchor to)" anchorChar string outer
 	| -Add Groups_Ini file path
 	/if (!${Ini[${MacroData_Ini},File Paths,Saved Groups].Length}) /call WriteToIni "${MacroData_Ini},File Paths,Saved Groups" "e3 Macro Inis\Saved Groups.ini" 1
 	| -Import Groups_Ini.
@@ -1605,6 +1607,7 @@ Sub basics_Background_Events
   /doevents outOfSomething
   /doevents ItemDeleteSummoned
   /call check_StoneOn
+  /call check_Anchor
 |		/varset event_counter 1
 |	} else {
 |		/varcalc event_counter ${event_counter}+1
@@ -1631,6 +1634,7 @@ SUB basics_CharacterSettings
 /call WriteToIni "${Character_Ini},Misc,AutoFood" Off
 /call WriteToIni "${Character_Ini},Misc,Food"
 /call WriteToIni "${Character_Ini},Misc,Drink"
+/call WriteToIni "${Character_Ini},Misc,Anchor (Char to Anchor to)" ""
 /if (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]}) {
 	/call WriteToIni "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" Off
 } else /if (${Me.Class.ShortName.NotEqual[BRD]}) {
@@ -2640,7 +2644,19 @@ sub check_PreviousSpell
   }
 
 /return
+sub check_Anchor
+  /if (${anchorChar.Length}>1 && ${Bool[${Spawn[${anchorChar}].ID}]} && ${Spawn[${anchorChar}].LineOfSight}) {
 
+    /if (!(${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 )) {
+
+      /if (${Spawn[${anchorChar}].Distance} > 15) {
+        
+        /echo moving to ancor
+        /moveto id ${Spawn[${anchorChar}].ID}
+      }
+    }
+  }
+/return
 |---------------------------------------------------------------------------------|
 | Centralized area to call methods that will be called every event loop
 | Warning only put things that check very quickly if they should be called or not.

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2063,6 +2063,9 @@ SUB check_Supply
 	/if (${Debug}) /echo |- check_Supply ==>
   /if (${Waiting4Rez}) /return
   /if (${Bool[${Me.Buff[Resurrection Sickness]}]}) /return
+  | Extra checks here because sometimes Waiting4Rez doesn't seem to short out supply
+  /call check_AmIDead 10 5
+  /if (${Macro.Return}) /return
 	/if (!${Defined[SupplyEnabled]}) /declare SupplyEnabled bool outer ${Bool[${Ini[${Character_Ini},Supply]}]}
   
   /if (!${SupplyEnabled}) /goto :endsupply
@@ -2083,16 +2086,25 @@ SUB check_Supply
 		/if (!${Defined[supplySpell]}) /declare supplySpell string local NULL
 		/if (!${Defined[supplyTimeout]}) /declare supplyTimeout timer local NULL
 		/if (!${Defined[supplyGem]}) /declare supplyGem int local NULL
-	
+    /if (!${Defined[supplyQuantity]}) /declare supplyQuantity int local NULL	
     | Loop through the string, then loop through each of the items on that key	
 		/for i 1 to ${Supply.Size}
 			/varset supplyItem ${Supply[${i}].Arg[1,|]}
 			/varset supplySpell ${Supply[${i}].Arg[2,|]}
 			/varset supplyTimeout ${Supply[${i}].Arg[3,|]}
 			/varset supplyGem ${Supply[${i}].Arg[4,|]}
+      /if (${Supply[${i}].Arg[5,|]}) {
+        /varset supplyQuantity ${Supply[${i}].Arg[5,|]}
+      } else {
+        /varset supplyQuantity 1
+      }
 			/if (!${Defined[SupplyTimer${i}]}) /declare SupplyTimer${i} timer outer 0
-			/if (!${Bool[${FindItem[=${supplyItem}]}]} && ${SupplyTimer${i}} == 0) {
-				/echo [${Time}]: Supply: Creating a ${supplyItem} using ${supplySpell}
+      /if (${FindItemCount[${supplyItem}]} < ${supplyQuantity} && ${SupplyTimer${i}} == 0 && ) {
+        /if (${FindItem[${supplyItem}].Lore} && ${supplyQuantity} > 1 && !${supplyItem.Equal[Summoned: Large Modulation Shard]}) {
+          /if (${Debug}) /echo [${Time}]: Supply item ${supplyItem} is Lore but has a specified quantity of ${supplyQuantity}
+          /return
+        }
+				/echo [${Time}]: Supply: Creating a ${supplyItem} using ${supplySpell} need ${supplyQuantity}
 				/delay 1
 				/tar ${Me}
 				/delay 1
@@ -2111,6 +2123,12 @@ SUB check_Supply
             /delay 2s
 				}
 
+        /declare j int local
+        /for j 1 to ${supplyQuantity}
+        /call check_HealCasting_DuringDetrimental
+        /if (!${c_SubToRun}) {
+          /return
+        }
 				/if (${supplyGem} == 0 || ${supplyGem} == NULL) { 
            
            /call check_ReadySimple "${supplySpell}"
@@ -2128,9 +2146,13 @@ SUB check_Supply
               /call castSimpleSpellBase "${supplySpell}/Gem|${supplyGem}" ${Me.ID} False
            }
 				}
-				/delay 20s ${Cursor.ID}
         /call ClearCursor
         /delay 1s
+        /if (${FindItemCount[${supplyItem}]} >= ${supplyQuantity}) {
+          /goto :supplyFinished
+        }
+        /next j
+        :supplyFinished
   		  
 				| If the item is a modulation shard, tell everyone to put it in their bag
 				/if (${supplyItem.Find[Modulation Shard]}) {
@@ -2144,7 +2166,7 @@ SUB check_Supply
 				| Memorize the previous spell if needed
 				/if (${Bool[${previousSpell}]}) {
 					/delay 1s
-					/echo ==> Supply: Memorizing ${previousSpell} to gem ${supplyGem}.
+					/echo [${Time}]: Supply: Memorizing ${previousSpell} to gem ${supplyGem}.
 					/call memorize_spell "${previousSpell}" "${supplyGem}"
 				}
 				/varset SupplyTimer${i} ${supplyTimeout}

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1526,6 +1526,9 @@ Sub basics_Setup
 	/declare medOn_combatBreak bool outer FALSE
 	/declare autoMedChar bool outer FALSE
   /declare anchorChar string outer 
+  /declare anchorOn bool outer FALSE
+  /squelch /alias /anchoroff /bcga //varset anchorOn FALSE
+  /squelch /alias /anchoron /bcga //varset anchorOn TRUE
   /declare medbreak_Popup_Timer timer outer
 	/declare clickitRandomDelay int outer 7
 
@@ -1544,7 +1547,8 @@ Sub basics_Setup
   /if (${Ini[${Character_Ini},Misc,End MedBreak in Combat(On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,End MedBreak in Combat(On/Off)" medOn_combatBreakChar bool outer
 	/if (${Ini[${Character_Ini},Misc,AutoMedBreak (On/Off)].Length}) /call iniToVarV "${Character_Ini},Misc,AutoMedBreak (On/Off)" autoMedChar bool outer
   /if (${Ini[${Character_Ini},Misc,Anchor (Char to Anchor to)].Length}) /call iniToVarV "${Character_Ini},Misc,Anchor (Char to Anchor to)" anchorChar string outer
-	| -Add Groups_Ini file path
+
+  | -Add Groups_Ini file path
 	/if (!${Ini[${MacroData_Ini},File Paths,Saved Groups].Length}) /call WriteToIni "${MacroData_Ini},File Paths,Saved Groups" "e3 Macro Inis\Saved Groups.ini" 1
 	| -Import Groups_Ini.
 	/if (!${Ini[${MacroData_Ini},File Paths,Saved Groups].Length}) {
@@ -1702,6 +1706,7 @@ Sub basics_Aliases
 	/squelch /alias /ResetCorpses /bc Fix Corpses
 	/squelch /alias /gathercorpses /echo Gather Corpses
 	/squelch /alias /mana /bc Report Mana
+
 /if (${Debug}) /echo <== basics_Aliases -|
 /return
 
@@ -2645,14 +2650,16 @@ sub check_PreviousSpell
 
 /return
 sub check_Anchor
-  /if (${anchorChar.Length}>1 && !${Me.Moving} && ${Bool[${Spawn[${anchorChar}].ID}]} && ${Spawn[${anchorChar}].LineOfSight}) {
-
+  /if (${anchorOn} && ${anchorChar.Length}>1 && !${Me.Moving} && ${Bool[${Spawn[${anchorChar}].ID}]} && ${Spawn[${anchorChar}].LineOfSight}) {
     /if (!(${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 )) {
-
-      /if (${Spawn[${anchorChar}].Distance} > 15) {
-        
+      /if (${Spawn[${anchorChar}].Distance} > 10) {
         /echo [${Time}] Anchor: Moving to Anchor
         /moveto id ${Spawn[${anchorChar}].ID}
+      } else {
+        |test to see if this stops the 'spin'
+        /if (${MoveTo.Moving}) {
+           /moveto off
+        }
       }
     }
   }

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2645,13 +2645,13 @@ sub check_PreviousSpell
 
 /return
 sub check_Anchor
-  /if (${anchorChar.Length}>1 && ${Bool[${Spawn[${anchorChar}].ID}]} && ${Spawn[${anchorChar}].LineOfSight}) {
+  /if (${anchorChar.Length}>1 && !${Me.Moving} && ${Bool[${Spawn[${anchorChar}].ID}]} && ${Spawn[${anchorChar}].LineOfSight}) {
 
     /if (!(${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 )) {
 
       /if (${Spawn[${anchorChar}].Distance} > 15) {
         
-        /echo moving to ancor
+        /echo [${Time}] Anchor: Moving to Anchor
         /moveto id ${Spawn[${anchorChar}].ID}
       }
     }

--- a/Macros/e3 Includes/e3_BuffCheck.inc
+++ b/Macros/e3 Includes/e3_BuffCheck.inc
@@ -40,9 +40,18 @@ SUB buffBots(ArrayName)
 	/if (${Select[${ArrayName},InstantBuffs2D,SelfBuffs2D]}) {
 		/varset buffTargetID ${Me.ID}
 		/varset buffTarget ${Me.Name}
+
 	} else /if (${Select[${ArrayName},CombatBuffs2D,BotBuffs2D]}) {
-		/varset buffTargetID ${Spawn[=${${ArrayName}[${s},${iCastTarget}]}].ID}
-		/varset buffTarget ${${ArrayName}[${s},${iCastTarget}]}
+   	/varset buffTargetID ${Spawn[=${${ArrayName}[${s},${iCastTarget}]}].ID}
+    /varset buffTarget ${${ArrayName}[${s},${iCastTarget}]}
+    |no buff target set, use self
+    /if (!${Bool[${Spawn[=${${ArrayName}[${s},${iCastTarget}]}].ID}]}) {
+      /varset buffTargetID ${Me.ID}
+      /varset buffTarget ${Me.Name}
+    }
+
+
+
 	} else /if (${Select[${ArrayName},PetBuffs2D]}) {
 		/varset buffTargetID ${Spawn[=${${ArrayName}[${s},${iCastTarget}]}].Pet.ID}
 		/varset buffTarget ${${ArrayName}[${s},${iCastTarget}]}

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -706,24 +706,24 @@ Sub memorize_spell(spellName,gemNum)
 	
 	|only wait for beneficial,self spells
 	|(${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0)
-	/declare isHealer bool Local ${Select[${Me.Class.ShortName},CLR,DRU,SHM]}
 	/declare timeTowait int local ${Math.Calc[35+(${Spell[${spellName}].RecastTime}/100)]}
-	 /if (${isHealer} && ${timeTowait}>30) {
-        /varset timeTowait 30
-    } 
 	/declare waitForReady timer local ${timeTowait}
 	|/echo wfr ${waitForReady} rc ${Spell[${spellName}].RecastTime} math ${Math.Calc[25+(${Spell[${spellName}].RecastTime}/100)]}
 	:checkTimer
 		
 		|/echo chectimer ${waitForReady} ${Me.SpellReady[${spellName}]}
 	/if (${waitForReady}) {
+		/call check_HealCasting_DuringDetrimental
+		/if (!${c_SubToRun}) {
+			/return
+		}
 		/doevents Follow
 		/doevents Stop
 		/doevents MoveHere
 		/doevents BackOff
 		/doevents Assist
 		/call alerts_Background_Events
-		
+
 		/if ((${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0)) {
 			|kick out as we are now in combat
 			/return

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -332,9 +332,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			
 			|bards songs don't work with /casting, have to do it ourselves
 			/if (${Bool[${Me.Book[${pendingCast}]}]} && ${Me.Class.ShortName.Equal[BRD]}) {
+				/call TrueTarget ${targetID}
 				/cast "${pendingCast}"
-               
-                /delay 5 ${Window[CastingWindow].Open}
+
+                /delay 10 ${Window[CastingWindow].Open}
                 
                 /if (!${Window[CastingWindow].Open}) {
                     /stopcast
@@ -468,7 +469,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					}
 				}
 						|-Moved since casting began
-				/if (${castEndTime}>5) {
+				/if (${castEndTime}>5 && !${Me.Class.ShortName.Equal[BRD]}) {
 					
 					/if (${Math.Distance[${startingLoc}]}>=8) {
 						/if (${Debug} || ${Debug_Casting}) /echo moved 8+ units after casting: called interrupt

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -1041,6 +1041,14 @@ sub BardSongWaitLockPumpQueue
     /if (!${Window[CastingWindow].Open}) {
       /break
     }
+    /if (${Auto_Loot}) {
+      /call check_Loot "on"
+    
+    }
+    /call check_Anchor
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
     /delay 1
   }
 

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -1,7 +1,7 @@
 |----------------------------------------------------------------------------|
 | Magician Functions
 |----------------------------------------------------------------------------|
-#event petWeapons "#1# tells you, 'Pet Weapon#*#'"
+|#event petWeapons "#1# tells you, 'Pet Weapon#*#'"
 #event petWeapons "#1# tells you, 'Distribute Pet Weapon#*#'"
 #event petWeapons "<#1#> Pet Weapon#*#"
 #event petWeapons "<#1#> Distribute Pet Weapon#*#"
@@ -63,261 +63,506 @@ sub event_petWeapons(line, ChatSender)
 /if (${Debug} || ${Debug_MAG}) /echo <== event_petWeapons -|
 /return
 
+
+#event armPets "<#1#> Pet Weapon#*#"
+#event armPets "<#1#> Arm Pets"
+#event armPets "<#1#> Arm Pets #2#"
+#event armPets "#1# tells you, 'Arm Pet'"
 #event armPets "#1# tells you, 'Arm Pets'"
+#event armPets "#1# tells you, 'Pet Weapon#*#'"
+#event armPets "#1# tells you, 'Pet Armor*#'"
+#event armPets "#1# tells you, 'Arm Pet #2#'"
 #event armPets "#1# tells you, 'Arm Pets #2#'"
-|#event armPets "<#1#> Arm Pets <#2#> <#3#>"
-sub event_armPets(line, ChatSender, loadType)
- /echo |- event_armPets ==>
-  
+sub event_armPets(line, ChatSender)
+/if (${Debug} || ${Debug_MAG})  /echo event_armPets ==>
+
+  | For some reason events dont like optional parameters, this is how to get the arguments after 'arm pets' in the tell
   /declare characterToWorkOn string local
-  
-  /if (${Bool[${loadType.Length}]}) {
-   /varset characterToWorkOn ${loadType.Token[2, ]}
-   /varset loadType ${loadType.Token[1, ]}
-   /if (${characterToWorkOn.Equal[NULL]}) {
-     |set to empty string
-     /varset characterToWorkOn  
-   }
-   |/echo LoadType:${loadType}
-   |/echo Character:${characterToWorkOn}
+  /declare loadType string local
+  /if (${line.Find[tells you]}) {
+    /if (${line.Token[6, ].Length}>0) /varset loadType ${line.Token[6, ]}
+    /if (${line.Token[7, ].Length}>0) /varset characterToWorkOn ${line.Token[7, ].Left[-1]}
+  } else {
+    /if (${line.Token[4, ].Length}>0) /varset loadType ${line.Token[4, ]}
+    /if (${line.Token[5, ].Length}>0) /varset characterToWorkOn ${line.Token[5, ].Left[-1]}
   }
-  
+  /if (${Debug} || ${Debug_MAG}) /echo [${Time}] LoadType: ${loadType}, CharacterToWorkOn: ${characterToWorkOn}
+
   |first check that we have an empty slot
   /declare BackSlotThatIsOpen int 0
+  /declare itemInSlotID int local 0
+  /declare itemInSlot string local NULL
   /declare i int local
+
   /for i 1 to 10
   /if (!${Bool[${InvSlot[pack${i}].Item.ID}]}) {
+
     /varset BackSlotThatIsOpen ${i}
     /goto :bagslotcheckdone
+
+  } else /if (!${Bool[${InvSlot[pack${i}].Item.Container}]}) {
+
+    /varset BackSlotThatIsOpen ${i}
+    /varset itemInSlotID ${i}
+    /varset itemInSlot ${InvSlot[pack${i}].Item.Name}
+    /goto :bagslotcheckdone
+
+  } else /if (${InvSlot[pack${i}].Item.Name.Equal[Phantom Satchel]} || ${InvSlot[pack${i}].Item.Name.Equal[Pouch of Quellious]}) {
+
+    /call findAndDestroyOldSatchels
+    /if (!${Bool[${InvSlot[pack${i}].Item.ID}]}) {
+      |/echo Pack slot ${i}
+      /varset BackSlotThatIsOpen ${i}
+      /goto :bagslotcheckdone
+    } else {
+      /if (${Bool[${InvSlot[pack${itemInSlotID}].Item.ID}]}) {
+        /echo [${Time}]: "Arm Pets: Bag slot not cleared. Exiting"
+        /goto :armpetend
+      }
+    }
   }
   /next i
   :bagslotcheckdone
+
+  | If an item was found in a pack slot, move the item to the first available slot inside a bag
+  /if (${itemInSlotID} > 0) {
+    /declare m int local 1
+    /declare n int local 1
+    /for m 1 to 10
+    /for n 1 to 10 
+    /if (!${InvSlot[pack${m}].Item.Item[${n}].ID}) {
+      /itemnotify pack${itemInSlotID} leftmouseup
+      /itemnotify in pack${m} ${n} leftmouseup
+      /goto :bagslotcleared
+    }
+    /next n
+    /next m
+    :bagslotcleared
+    /if (${Cursor.ID}) {
+      /tell ${ChatSender}  Arm Pets: Unable to clear bagslot. Exiting
+      /goto :armpetend
+    }
+    /if (${Bool[${InvSlot[pack${itemInSlotID}].Item.ID}]}) {
+      /echo [${Time}]: "Arm Pets: Bag slot not cleared. Exiting"
+      /goto :armpetend
+    }
+  }
+
   /if (${BackSlotThatIsOpen}==0) {
     |no empty bag slot available
     /tell ${ChatSender}  Arm Pets: No empty bag slot on mage. Exiting.
     /goto :armpetend
   } 
  
+  /tell ${ChatSender} Starting to arm pets. Stand close.
 
-  /tell ${ChatSender} Starting the arming of group pets.
-  |note for the weapons, you need na empty bag slot for this to work.
-  /declare counter int local 0
-  /declare bodytype string local
-  /declare char_class string local
-  /declare primaryWeapon string local
-  /declare secondaryWeapon string local 
-
-  |/echo Character:${characterToWorkOn}
-  |/echo loadType:${loadType}
+  | When finished, will try to move mage back to their original location
+  /declare meY float local ${Me.Y}
+  /declare meX float local ${Me.X}
 
   /if (${Cursor.ID}) {
-    /echo Arm Pets: Something is on your cursor, exiting.
+    /echo [${Time}]: Arm Pets: Something is on your cursor, exiting.
+    | delays are needed as back to back tells fail to send
+    /delay 3s 
     /tell ${ChatSender}  Arm Pets: Error, check mage for detail.
     /goto :armpetend
   }
-  |/echo got to for loop: ${characterToWorkOn.Length} : ${characterToWorkOn.Length}>0]}
-  /for counter 0 to 5
-    |if character name is supplied, skip everything but the character to work on. 
-    |/echo checking character: [${characterToWorkOn}] vs [${Spawn[${Group.Member[${counter}]}].Name}]
-   
-    /if (${characterToWorkOn.Length}>0 && !${characterToWorkOn.Equal[${Spawn[${Group.Member[${counter}]}].Name}]}) /continue
-    
-    /varset bodytype ${Spawn[${Group.Member[${counter}]}].Pet.Body}
-    
-    /if (${Spawn[${Group.Member[${counter}]}].Pet.ID} && !${Spawn[${Group.Member[${counter}]}].Pet.Name.Find[familiar]} && ${Spawn[${Group.Member[${counter}]}].Pet.Level}>1) {
-      
-      /bc Arm Pets: Working on ${Spawn[${Group.Member[${counter}]}].Name} 's pet
+
+  | Determine if player is in my group
+  /if (${Group.Leader.ID}>0) {
+    /declare g int local
+    /declare memberOfMyGroup bool local
+    /for g 0 to ${Group.Members}
+      /if (${ChatSender.Equal[${Spawn[${Group.Member[${g}].Name}]}]}) /varset memberOfMyGroup true
+    /next g
+  }
+
+  |/echo Character to work on is: ${characterToWorkOn}
+  /declare groupCounter int local
+  /if (${Bool[${line.Find[pet weapon]}]} || ${Bool[${line.Find[pet armor]}]} || !${loadType.Length}>0) { 
+    | For compatibility, if player calls pet weapon it will only give armor/heirloom
+    /echo [${Time}]: Pet Weapon was called, only handing armor/heirloom to pet
+    /if (${Spawn[${ChatSender}].Pet.Level}<45) {
+        /call armOnePet ${ChatSender} ${ChatSender} lowerpet
+    } else {
+      /delay 3s
+      /tell ${ChatSender}  Either Pet Weapon was called or you did not specify a loadout, only givng Armor and Heirlooms to your pet.
+      /call armOnePet ${ChatSender} ${ChatSender} noweapon
+    }
+
+  } else /if (${characterToWorkOn.Length} > 0) {
+
+    | User passed in a comma separated list of toons to work on
+    /if (${characterToWorkOn.Find[,]}) {
+
+      /declare currentChar string local
+
+      /for groupCounter 1 to ${Math.Calc[${characterToWorkOn.Count[,]}+1]}
+
+      /varset currentChar ${characterToWorkOn.Arg[${groupCounter},,]}
+      |/echo [${Time}]: Working on ${Spawn[${characterToWorkOn.Arg[${groupCounter},,]}].Name}
+      /if (${Spawn[${currentChar}].ID}>0) {
+        /call armOnePet ${currentChar} ${ChatSender} ${loadType}
+        /if (${Cursor.ID}) {
+          /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
+          /goto :armpetend
+        } 
+      } else {
+        /delay 3s
+        /tell ${ChatSender} Could not locate ${currentChar}, skipping.
+      }
+      /next groupCounter
+
+    } else {
+      | Character name was provided, arm only their pet
+      |/echo Have one character to work on. Char: ${characterToWorkOn} Spawn ID: ${Spawn[${characterToWorkOn}].ID}
+      /if (${Spawn[${characterToWorkOn}].ID}>0) {
+        |/echo [${Time}]: found Character to work on.
+
+        /call armOnePet ${characterToWorkOn} ${ChatSender} ${loadType} 
+      } else {
+        /delay 3s
+        |/echo [${Time}]: Didnt find character ${characterToWorkOn}
+        /tell ${ChatSender}  Could not locate character ${characterToWorkOn}
+      }
+    }
+
+  } else /if (${memberOfMyGroup}) {
+    | Character is a member of my group, arm all pets in group
+    /for groupCounter 0 to ${Group.Members}
+    /call armOnePet ${Spawn[${Group.Member[${groupCounter}].Name}]} ${ChatSender} ${loadType} 
+    /if (${Cursor.ID}) {
+      /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
+      /goto :armpetend
+    }    
+    /next groupCounter
+
+  } else { 
+    | When the chat sender is not a member, arm only their pet
+    |/echo [${Time}]: Arming ${ChatSender} 's Pet
+    /call armOnePet ${ChatSender} ${ChatSender} ${loadType} 
+  }
+
+  /call findAndDestroyOldSatchels
+  /if (${itemInSlotID} > 0) {
+    |/echo [${Time}]: Item to put back ${itemInSlot}
+    /if (${FindItemCount[${itemInSlot}]} > 0) {
+      /itemnotify "${itemInSlot}" leftmouseup
+    } else {
+      |/echo [${Time}]: Could not find item to put back ${itemInSlot}
+      /if (${itemInSlot.Equal[Folded Pack of Spectral Armaments]}) {
+        /call castSimpleSpell "Grant Spectral Armaments" ${Me.ID}
+      } else /if (${itemInSlot.Equal[Folded Pack of Enibik's Heirlooms]}) {
+        /call castSimpleSpell "Grant Enibik's Heirlooms" ${Me.ID}
+      } else /if (${itemInSlot.Equal[Folded Pack of Spectral Plate]}) {
+        /call castSimpleSpell "Grant Spectral Plate" ${Me.ID}
+      }
+    }
+    /delay 3s ${Bool[${Cursor.ID}]}
+    /call ClearCursor
+  }
+  /if (${Cursor.ID}) {
+    /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
+    /goto :armpetend
+  }
+
+  /delay 3s
+  /tell ${ChatSender} Finished arming pets.
+  :armpetend
+  /moveto loc ${meY} ${meX}
+
+/if (${Debug} || ${Debug_MAG}) /echo <== event_armPets -|
+/return
+
+sub armOnePet(playerName, chatSender, loadoutType)
+
+    /declare fireWeapon string local "Summoned: Fist of Flame"
+    /declare iceWeapon string local "Summoned: Orb of Chilling Water"
+    /declare malaWeapon string local "Summoned: Spear of Maliciousness"
+    /declare slowWeapon string local "Summoned: Mace of Temporal Distortion"
+    /declare dispelWeapon string local "Summoned: Wand of Dismissal"
+    /declare wardWeapon string local "Summoned: Short Sword of Warding"
+    /declare drainingBuckler string local "Summoned: Buckler of Draining Defense"
+    /declare clericHammer string local "Hammer of Damnation"
+
+    /declare bodytype string local
+    /declare char_class string local
+    /declare primaryWeapon string local
+    /declare secondaryWeapon string local 
+
+    |/echo [${Time}]: Checking ${playerName} 's pet
+    |/echo [${Time}]: ${Spawn[${playerName}].Name} the ${Spawn[${playerName}].Class} has pet: ${Spawn[${playerName}].Pet.ID} which is ${bodytype}
+    /if (${Spawn[${playerName}].Pet.ID} && !${Spawn[${playerName}].Pet.Name.Find[familiar]} && ${Spawn[${playerName}].Pet.Level}>1) {
+
+      /bc Arm Pets: Working on ${playerName} 's pet
+
+      |/call TrueTarget ${Spawn[${playerName}].Pet.ID}
+      |/echo [${Time}]: Pet distance is ${Spawn[${playerName}].Pet.Distance}
+      /if (${Spawn[${playerName}].Pet.Distance}>50) {
+        /echo [${Time}]: Pet is too far away.
+        /delay 3s 
+        /tell ${chatSender}  ${playerName}'s pet too far away.
+        /return
+
+      }
       /if (${Me.Book[Grant Enibik's Heirlooms]}) {
            /bc Arm Pets: Creating Heirlooms
-           /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
+           /call summonUnpackAndGive ${Spawn[${playerName}].Pet.ID} "Grant Enibik's Heirlooms" "Folded Pack of Enibik's Heirlooms"
       } 
       /if (${Cursor.ID}) {
         /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /goto :armpetend
+        /return
       }
       /if (${Me.Book[Grant Spectral Plate]}) {
         /bc Arm Pets: Creating Spectral Plate
-        /call summonUnpackAndGive ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
+        /call summonUnpackAndGive ${Spawn[${playerName}].Pet.ID} "Grant Spectral Plate" "Folded Pack of Spectral Plate"
       }
       /if (${Cursor.ID}) {
         /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /goto :armpetend
+        /return
       }
+    
       
-      /if (${Me.Book[Grant Spectral Armaments]}) {
-        |/echo the line to parse is:${loadType}
-        /varset char_class ${Spawn[${Group.Member[${counter}]}].Class} 
-        /if (${char_class.Find[Shadow Knight]}) {
-          
-          |/echo Arm Pet: Doing ${char_class} loadout
-          
-          /if (${loadType.Find[fire]}) {
+      |/echo [${Time}]: the line to parse is:${loadoutType}
+      /if (${Me.Book[Grant Spectral Armaments]} && !${loadoutType.Find[none]} && !${loadoutType.Find[noweapon]}) {
+        /varset char_class ${Spawn[${playerName}].Class} 
+        |/echo [${Time}]: loadoutType: ${loadoutType}
 
-            /varset primaryWeapon "Summoned: Fist of Flame"
-            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+        |/echo [${Time}]: Pet level is ${Spawn[${playerName}].Pet.Level}
+        /if (${Spawn[${playerName}].Pet.Level}<45) {
+          | This will rely on gimme setup to get hammers from your cleric, otherwise we can just give the buckler
+          |/echo [${Time}]: Pet is below 45, giving buckler and cleric hammer.
 
-          } else /if (${loadType.Find[ice]}) {
-            
-            /varset primaryWeapon "Summoned: Orb of Chilling Water"
-            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-            
-          } else /if (${loadType.Find[2dispel]}) {
-            
-            /varset primaryWeapon "Summoned: Wand of Dismissal"
-            /varset secondaryWeapon "Summoned: Wand of Dismissal"
-
+          /varset secondaryWeapon ${drainingBuckler}
+          /if (${FindItemCount[${clericHammer}]}>0) {
+            /varset primaryWeapon ${clericHammer}
           } else {
-            
-            /varset primaryWeapon "Summoned: Wand of Dismissal"
-            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-        
+            /varset primaryWeapon NOPRIMARY
+            /delay 3s
+            /tell ${chatSender} Pet ${Spawn[${playerName}].Pet.CleanName} is below level 45, you should ask a cleric for a Pet Hammer when I am finished.
           }
-        
-        } else /if (${char_class.Find[Druid]}) {
-          |/echo Arm Pet: Doing ${char_class} loadout
-          /if (${loadType.Find[fire]}) {
 
-            /varset primaryWeapon "Summoned: Fist of Flame"
-            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
+        } else /if (${loadoutType.Find[,]} || ${loadoutType.Find[2]}) {
+          |/echo [${Time}]: Token1 ${loadoutType.Token[1,,]} Token2 ${loadoutType.Token[2,,]} 
+          /declare firstItem string local
+          /declare secondItem string local
 
-          } else /if (${loadType.Find[ice]}) {
-            
-            /varset primaryWeapon "Summoned: Orb of Chilling Water"
-            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-            
-          } else /if (${loadType.Find[2dispel]}) {
-            
-            /varset primaryWeapon "Summoned: Wand of Dismissal"
-            /varset secondaryWeapon "Summoned: Wand of Dismissal"
-
-          } else {
-            
-            /varset primaryWeapon "Summoned: Wand of Dismissal"
-            /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-        
-          }
-          |grouped mage/nec/enc here, will probably have to split out depending on new payloads
-        } else /if (${char_class.Find[Magician]} || ${char_class.Find[Necro]} || ${char_class.Find[Enchanter]}) {
-          |/echo Arm Pet: Doing ${char_class} loadout
-          /if (${loadType.Find[fire]}) {
-
-            /varset primaryWeapon "Summoned: Fist of Flame"
-            /varset secondaryWeapon "Summoned: Fist of Flame"
-
-          } else /if (${loadType.Find[ice]}) {
-            
-            /varset primaryWeapon "Summoned: Orb of Chilling Water"
-            /varset secondaryWeapon "Summoned: Orb of Chilling Water"
-            
-          } else /if (${loadType.Find[2dispel]}) {
-            
-            /varset primaryWeapon "Summoned: Wand of Dismissal"
-            /varset secondaryWeapon "Summoned: Wand of Dismissal"
-
-          } else {
-            
-            /varset primaryWeapon "Summoned: Mace of Temporal Distortion"
-            /varset secondaryWeapon "Summoned: Wand of Dismissal"
-        
+          /if (${loadoutType.Find[2]}) {
+            |/echo [${Time}]: Setting loadout type for same primary/secondary: ${loadoutType},${loadoutType}
+            /varset loadoutType ${loadoutType},${loadoutType}
           }
           
+          /if (${loadoutType.Token[1,,].Length}>0) {
+            /varset firstItem ${loadoutType.Token[1,,]}
+
+            /if (${firstItem.Find[fire]}) {
+              /varset primaryWeapon ${fireWeapon}
+
+            } else /if (${firstItem.Find[ice]}) {
+              /varset primaryWeapon ${iceWeapon}
+
+            } else /if (${firstItem.Find[slow]}) {
+              /varset primaryWeapon ${slowWeapon}
+
+            } else /if (${firstItem.Find[mala]}) {
+              /varset primaryWeapon ${malaWeapon}
+
+            } else /if (${firstItem.Find[dispel]}) {
+              /varset primaryWeapon ${dispelWeapon}
+
+            } else /if (${firstItem.Find[ward]}) {
+              /varset primaryWeapon ${wardWeapon}
+
+            } else {
+              /delay 3s
+              /tell ${chatSender}  Invalid primary weapon specified, skipping weapon step.
+              /return
+            }
+          }
+
+          /if (${loadoutType.Token[2,,].Length}>0) {
+            /varset secondItem ${loadoutType.Token[2,,]}
+
+            /if (${secondItem.Find[fire]}) {
+              /varset secondaryWeapon ${fireWeapon}
+
+            } else /if (${secondItem.Find[ice]}) {
+              /varset secondaryWeapon ${iceWeapon} 
+
+            } else /if (${secondItem.Find[mala]}) {
+              /varset secondaryWeapon ${malaWeapon}
+
+            } else /if (${secondItem.Find[dispel]}) {
+              /varset secondaryWeapon ${dispelWeapon}
+
+            } else /if (${secondItem.Find[slow]}) {
+              /varset secondaryWeapon ${slowWeapon}
+
+            } else /if (${secondItem.Find[shield]}) {
+              /varset secondaryWeapon ${drainingBuckler}
+
+            } else {
+              /delay 3s
+              /tell ${chatSender}  Invalid secondary weapon specified, skipping weapon step.
+              /return
+            }
+          }
+
+        } else /if (${loadoutType.Find[default]} || ${loadoutType.Find[class]}) {
+
+            /if (${char_class.Find[Magician]} || ${char_class.Find[Necro]} || ${char_class.Find[Beastlord]}) {
+              |/echo [${Time}]: Arm Pet: Doing ${char_class} loadout
+              /if (${loadoutType.Find[ice]}) {
+                /varset primaryWeapon ${iceWeapon}
+                /varset secondaryWeapon ${iceWeapon}
+                
+              } else {
+                /varset primaryWeapon ${fireWeapon}
+                /varset secondaryWeapon ${fireWeapon}
+              }
+            } else {
+              |When its any other class with pet
+              |/echo [${Time}]: loadoutType: ${loadoutType}
+              /echo Arm Pet: Doing Default ${char_class} loadout
+              
+              /varset primaryWeapon ${dispelWeapon}
+              /varset secondaryWeapon ${malaWeapon}
+            }
         } else {
-          |/echo Arm Pet: Doing Default ${char_class} loadout
-          /varset primaryWeapon "Summoned: Wand of Dismissal"
-          /varset secondaryWeapon "Summoned: Spear of Maliciousness"
-
+          /delay 3s 
+          /tell ${chatSender}  Invalid loadout specified, skipping weapon step.
+          /return
         }
 
         /bc Arm Pets: Selected Weapons are ${primaryWeapon} and ${secondaryWeapon}
         /bc Arm Pets: Creating Weapons
-        /call summonUnpackAndSelect ${Spawn[${Group.Member[${counter}]}].Pet.ID} "Grant Spectral Armaments" "Folded Pack of Spectral Armaments" ${primaryWeapon} ${secondaryWeapon}
-      }
-      /if (${Cursor.ID}) {
-        /bc Arm Pets: Something went wrong and something is on your cursor, exiting.
-        /goto :armpetend
-      }
 
+        /call summonUnpackAndSelect ${Spawn[${playerName}].Pet.ID} "Grant Spectral Armaments" "Folded Pack of Spectral Armaments" ${primaryWeapon} ${secondaryWeapon}
+      }
     }
-    |/echo ${Spawn[${Group.Member[${counter}]}].Name} the ${Spawn[${Group.Member[${counter}]}].Class} has pet: ${Spawn[${Group.Member[${counter}]}].Pet.ID} which is ${bodytype}
-  /next counter
-  /tell ${ChatSender} Finished arming pets.
-:armpetend
-/if (${Debug} || ${Debug_MAG}) /echo <== event_armPets -|
+    
+
 /return
+
 sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryItem)
 
-     
-        /call castSimpleSpell "${spellName}" ${Me.ID}
-        /delay 3s ${Bool[${Cursor.ID}]}
-        |/echo done casting, put in inventory
+        /declare clericHammer string local "Hammer of Damnation"
+        /declare drainingBuckler string local "Summoned: Buckler of Draining Defense"
+        /if (${FindItemCount[${ItemName}]} > 0) {
+          |/echo [${Time}]: found ${ItemName}
+          /itemnotify "${ItemName}" leftmouseup
+        } else {
+          /call castSimpleSpell "${spellName}" ${Me.ID}
+          /delay 3s ${Bool[${Cursor.ID}]}
+        }
+
+        |/echo [${Time}]: done casting, put in inventory
         /call ClearCursor
         /delay 3s !${Bool[${Cursor.ID}]}
         /delay 1s
-        |/echo unfolding the bag to cursor
+        |/echo [${Time}]: unfolding the bag to cursor
         /ItemNotify "${ItemName}" rightmouseup
         /delay 3s ${Bool[${Cursor.ID}]}
         /call ClearCursor
         /delay 3s !${Bool[${Cursor.ID}]}
         /delay 1s
-        /itemnotify "${primaryItem}" leftmouseup
-        /delay 5s ${Bool[${Cursor.ID}]}
-        /if (!${Cursor.ID}) {
-          /echo summonUnpackAndSelect: Could not load parimary item to cursor, exiting
-          /return
+
+        | If its a cleric hammer and mage does not have one already, just skip the primary section
+        |/if (!${primaryItem.Find[${clericHammer}]} || (${primaryItem.Find[${clericHammer}]} && ${FindItemCount[${clericHammer}]}>0)) {
+         /if (!${primaryItem.Equal[NOPRIMARY]}) {
+          /echo [${Time}]: Giving Primary Weapon to pet: ${primaryItem}
+          /itemnotify "${primaryItem}" leftmouseup
+          /delay 5s ${Bool[${Cursor.ID}]}
+          /if (!${Cursor.ID}) {
+            /echo [${Time}]: summonUnpackAndSelect: Could not load primary item to cursor, exiting
+            /return
+          }
+          |/echo giving primary item to pet
+          /call TrueTarget ${targetID}
+          /if (${Target.ID} && ${Target.Distance}<50) {
+            /call MoveToLoc ${Target.Y} ${Target.X} 50 15
+            /call giveItemOnCursorToTarget
+          } else {
+            /echo [${Time}]: Pet is too far away.
+            /return
+          }
         }
 
-        |/echo getting the target of the pet
-        /call TrueTarget ${targetID}
-        /if (${Target.ID} && ${Target.Distance}>19) /call MoveToLoc ${Target.Y} ${Target.X} 50 15
-
-
-        |/echo giving primary item to pet
-        /call giveItemOnCursorToTarget
         /if (${Cursor.ID}) {
-          /echo summonUnpackAndSelect: Something went wrong and something is on your cursor, exiting.
+          /echo [${Time}]: summonUnpackAndSelect: Something went wrong and something is on your cursor, exiting.
           /return
         }
 
         |check to see if we have a 2ndary item
-        /if (!${Bool[${FindItem[${secondaryItem}]}]}) {
-         
-         |we don't have the 2ndary item in this pack, summon the pack again and try again
-         |now delete the object
-          /itemnotify "Pouch of Quellious" leftmouseup
-          /delay 5s ${Bool[${Cursor.ID}]}
-          /if (${Cursor.Name.Find[Pouch of Quellious]}) {
-            /destroy
+        /if (${secondaryItem.Length}>0) {
+          /if (!${Bool[${FindItem[${secondaryItem}]}]}) {
+          
+          |we don't have the 2ndary item in this pack, summon the pack again and try again
+          |now delete the object
+            /itemnotify "Pouch of Quellious" leftmouseup
+            /delay 5s ${Bool[${Cursor.ID}]}
+            /if (${Cursor.Name.Find[Pouch of Quellious]}) {
+              /destroy
+            } else {
+              /echo [${Time}]: summonUnpackAndSelect: Could not destroy bag, exiting
+              /return
+            }
+            
+            /if (${FindItemCount[${ItemName}]} > 0) {
+              |/echo found ${ItemName}
+              /itemnotify "${ItemName}" leftmouseup
+            } else {
+              /call castSimpleSpell "${spellName}" ${Me.ID}
+              /delay 3s ${Bool[${Cursor.ID}]}
+            }
+
+            |/echo done casting, put in inventory
+            /call ClearCursor
+            /delay 3s !${Bool[${Cursor.ID}]}
+            |/echo unfolding the bag to cursor
+            /ItemNotify "${ItemName}" rightmouseup
+            /delay 3s ${Bool[${Cursor.ID}]}
+            /call ClearCursor
+            /delay 3s !${Bool[${Cursor.ID}]}
+            /call TrueTarget ${targetID}
+          } 
+        
+          |2ndary item
+          /if (${secondaryItem.Find[${drainingBuckler}]}) {
+            | for some reason itemnotify cant get the buckler by name or invslot, have to look for its pack slot
+            /echo [${Time}]: Giving buckler to pet: ${secondaryItem}
+            /declare i int local
+            /for i 1 to 10
+            /if (${Bool[${InvSlot[pack${i}].Item.Name.Equal[Pouch of Quellious]}]}) {
+              /itemnotify in pack${i} 5 leftmouseup
+              /goto :pouchFound
+            }
+            /next i
+            :pouchFound
           } else {
-            /echo summonUnpackAndSelect: Could not destroy bag, exiting
+            /echo [${Time}]: Giving Secondary weapon to pet: ${secondaryItem}
+            /itemnotify "${secondaryItem}" leftmouseup
+          }
+          
+          /delay 5s ${Bool[${Cursor.ID}]}
+          
+          /if (!${Cursor.ID}) {
+            /echo [${Time}]: summonUnpackAndSelect: Could not load secondary item to cursor.
             /return
           }
-          /call castSimpleSpell "${spellName}" ${Me.ID}
-          /delay 3s ${Bool[${Cursor.ID}]}
-          |/echo done casting, put in inventory
-          /call ClearCursor
-          /delay 3s !${Bool[${Cursor.ID}]}
-          |/echo unfolding the bag to cursor
-          /ItemNotify "${ItemName}" rightmouseup
-          /delay 3s ${Bool[${Cursor.ID}]}
-          /call ClearCursor
-          /delay 3s !${Bool[${Cursor.ID}]}
+          
+          |/echo giving secondary item to pet
           /call TrueTarget ${targetID}
-        } 
-       
-        |2ndary item
-        /itemnotify "${secondaryItem}" leftmouseup
-        /delay 5s ${Bool[${Cursor.ID}]}
-        
-        /if (!${Cursor.ID}) {
-          /echo summonUnpackAndSelect: Could not load parimary item to cursor, exiting
-          /return
+          /if (${Target.ID} && ${Target.Distance}<50) {
+            /call MoveToLoc ${Target.Y} ${Target.X} 50 15
+            /call giveItemOnCursorToTarget
+          } else {
+            /echo [${Time}]: Pet is too far away.
+            /return
+          }
         }
-
-        
-        |/echo giving secondary item to pet
-        /call giveItemOnCursorToTarget
         /if (${Cursor.ID}) {
-          /echo summonUnpackAndSelect: Something went wrong and something is on your cursor, exiting.
+          /echo [${Time}]: summonUnpackAndSelect: Something went wrong and something is on your cursor.
           /return
         }
       
@@ -327,35 +572,74 @@ sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryI
         /if (${Cursor.Name.Find[Pouch of Quellious]}) {
            /destroy
         } else {
-          /echo summonUnpackAndSelect: Could not destroy bag, exiting
+          /echo [${Time}]: summonUnpackAndSelect: Could not destroy bag.
           /return
         }
-
-      
 
 /return
-sub summonUnpackAndGive(targetID, spellName, ItemName)
+sub findAndDestroyOldSatchels()
 
-     
-        /call castSimpleSpell "${spellName}" ${Me.ID}
-        /delay 3s ${Bool[${Cursor.ID}]}
-        /delay 1s
-        |/echo done casting, put in inventory
-        /autoinventory
-        /delay 3s !${Bool[${Cursor.ID}]}
-        /delay 1s
-        |/echo unfolding the bag to cursor
-        /ItemNotify "${ItemName}" rightmouseup
-         /delay 3s ${Bool[${Cursor.ID}]}
-        |/echo getting the target of the pet
-        /call TrueTarget ${targetID}
-        /if (${Target.ID} && ${Target.Distance}>19) /call MoveToLoc ${Target.Y} ${Target.X} 50 15
-        /call giveItemOnCursorToTarget
+    /echo [${Time}]: Finding and destroying opened summoned packs
+    | Just in case mage has been looting and items ended up in an old phantom pack
+    /call ClearCursor
+    /if (${Cursor.ID}) {
+      /echo [${Time}]: findAndDestroyOldSatchels: Unable to clear cursor.
+      /return
+    }
+    /declare m int local
+    /declare n int local
+    /for m 1 to 10
+    /if (${InvSlot[pack${m}].Item.Name.Equal[Phantom Satchel]} || ${InvSlot[pack${m}].Item.Name.Equal[Pouch of Quellious]}) {
+      /for n 1 to 10
+      |/echo Item ${InvSlot[pack${m}].Item.Item[${n}].Name}
+      /if (!${InvSlot[pack${m}].Item.Item[${n}].NoRent} && ${InvSlot[pack${m}].Item.Item[${n}].ID} > 0) {
+        /echo [${Time}]: findAndDestroyOldSatchels: Non-Temporary Item ${InvSlot[pack${m}].Item.Item[${n}]} found in ${InvSlot[pack${m}].Item.Name}.
+        /return
+      }
+      /next n
+      /itemnotify pack${m} leftmouseup
+      /if (${Cursor.Name.Find[Phantom Satchel]} || ${Cursor.Name.Find[Pouch of Quellious]}) {
+        /destroy
         /if (${Cursor.ID}) {
-          /echo summonUnpackAndGive: Something went wrong and something is on your cursor, exiting.
+          /echo [${Time}]: findAndDestroyOldSatchels: Unable to clear bagslot.
           /return
         }
-      
+      }
+    }
+    /next m
+  /return
+
+sub summonUnpackAndGive(targetID, spellName, ItemName)
+
+    /if (${FindItemCount[${ItemName}]} > 0) {
+      |/echo ItemFound: ${ItemName}
+      /itemnotify "${ItemName}" leftmouseup
+    } else {
+      /call castSimpleSpell "${spellName}" ${Me.ID}
+      /delay 3s ${Bool[${Cursor.ID}]}
+    }
+
+    /delay 1s
+    |/echo done casting, put in inventory
+    /autoinventory
+    /delay 3s !${Bool[${Cursor.ID}]}
+    /delay 1s
+    |/echo unfolding the bag to cursor
+    /ItemNotify "${ItemName}" rightmouseup
+    /delay 3s ${Bool[${Cursor.ID}]}
+    |/echo getting the target of the pet
+    /call TrueTarget ${targetID}
+    /if (${Target.ID} && ${Target.Distance}<50) {
+      /call MoveToLoc ${Target.Y} ${Target.X} 50 15
+      /call giveItemOnCursorToTarget
+    } else {
+      /echo [${Time}]: Pet is too far away.
+      /return
+    }
+    /if (${Cursor.ID}) {
+      /echo [${Time}]: summonUnpackAndGive: Something went wrong and something is on your cursor, exiting.
+      /return
+    }
 
 /return
 sub giveItemOnCursorToTarget()
@@ -372,7 +656,7 @@ sub giveItemOnCursorToTarget()
         /if (${retryWeapTimer} && ${Cursor.ID}) {
           /goto :OpenTrade_Loop
         } else {
-          /echo Failed to open trade with ${Target.CleanName}.
+          /echo [${Time}]: Failed to open trade with ${Target.CleanName}.
         }
     } else {
         :WaitAccept_Loop
@@ -382,7 +666,7 @@ sub giveItemOnCursorToTarget()
           /if (${retryWeapTimer}) {
             /goto :WaitAccept_Loop
           } else {
-            /echo Failed to open trade with ${Target.CleanName}.
+            /echo [${Time}]: Failed to open trade with ${Target.CleanName}.
           }
         }
       }

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -10,7 +10,14 @@
 #event lootRelay "[#1#(msg)] loot #2#"
 SUB Event_lootRelay(line, ChatSender, looting)
   /if (${Me.Name.Equal[${ChatSender}]}) /return
-  /if (!${Defined[Auto_Loot]}) /declare Auto_Loot bool outer TRUE
+  /docommand ${ChatToggle} Looting Turned ${looting}
+  /call check_Loot "${looting}""
+
+/return
+
+Sub check_Loot(looting)
+
+ /if (!${Defined[Auto_Loot]}) /declare Auto_Loot bool outer TRUE
   /if (!${Defined[LootOnly]}) /declare LootOnly bool outer FALSE
   /if (!${Defined[LootOnlyItem]}) /declare LootOnlyItem string outer
   
@@ -34,12 +41,10 @@ SUB Event_lootRelay(line, ChatSender, looting)
   /if (${Select[${looting},on]}) {
     /varset Auto_Loot TRUE
     /varset LootOnly FALSE
-    /docommand ${ChatToggle} Looting Enabled
-    /if (${Me.CombatState.NotEqual[Combat]} || ${combatLooting}) /call loot_Area
-
   } else /if (${Select[${looting},off]}) {
     /varset Auto_Loot FALSE
-    /docommand ${ChatToggle} Looting Disabled
+    |exit
+    /return
   } else {
     /varset Auto_Loot TRUE
     /varset LootOnly TRUE
@@ -47,11 +52,10 @@ SUB Event_lootRelay(line, ChatSender, looting)
       /varset looting Diamond Coin
     }
     /varset LootOnlyItem ${looting}
-    /docommand ${ChatToggle} ${looting}s Only Enabled
-    /if (${Me.CombatState.NotEqual[Combat]} || ${combatLooting}) /call loot_Area
   }
-/return
+  /if (!((${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 )) || ${combatLooting}) /call loot_Area
 
+/return
 |----------------------------------------------------------------|
 |- Adds corpses that are not yours to the looted corpse list.	  -|
 #EVENT NotYourKill "Someone is already looting that corpse."
@@ -64,13 +68,17 @@ SUB EVENT_NotYourKill
 |--------------------------------------------------------------------------|
 |- Moves to corpses and begins looting, reads Loot_Ini for loot handles.	-|
 SUB loot_Area
+  /declare NumCorpses int local ${SpawnCount[npc corpse zradius 50 radius ${seek_Radius} "_"]}
+  /if (${NumCorpses}<1) {
+    /return
+  }
   /if (${NetBots[Creamo].ID}) /varset Debug_Loot TRUE
   /if (${Debug} || ${Debug_Loot}) /echo |- loot_Area ==>
   /declare startX int ${Me.X}
   /declare startY int ${Me.Y}
-  /squelch /hidecor looted
-  /if (${Twist.Twisting}) /call pauseTwist
-  /delay 5s !${Me.Casting.ID}
+  
+  |/if (${Twist.Twisting}) /call pauseTwist
+  |/delay 5s !${Me.Casting.ID}
   /if (${NetAdvPath.Following}) /squelch /netfollow off
   /if (${Stick.Active}) /squelch /stick off
 
@@ -82,7 +90,7 @@ SUB loot_Area
   /declare CorpseList_Looted  string local
   /declare i int local
   /declare c int local
-  /declare NumCorpses int local ${SpawnCount[npc corpse zradius 50 radius ${seek_Radius} "_"]}
+ 
   /declare CorpsesLeft int local ${NumCorpses}
   /varset cantLootCorpseCount 0
   /if (${Debug} || ${Debug_Loot}) /echo NumCorpses: ${NumCorpses}
@@ -92,7 +100,9 @@ SUB loot_Area
     /varset CorpseList ${CorpseList}${ClosestCorpse}|
   /next i
   /if (${Debug} || ${Debug_Loot}) /echo CorpseList: ${CorpseList}
-
+  /if (${NumCorpses}>1) {
+    /squelch /hidecor looted
+  }
   /for i 1 to ${NumCorpses}
     /if (${Debug} || ${Debug_Loot}) /echo Corpse ${i} of ${NumCorpses}, ${CorpsesLeft} left
     |iterate list of corpses
@@ -137,6 +147,7 @@ SUB loot_Area
   } else {
     /call MoveToLoc ${startY} ${startX} 15 20
   }
+  /squelch /hidecor npc 
   /docommand ${ChatToggle} ${Group.Leader} Looting Complete
   /if (${Debug} || ${Debug_Loot}) /echo <== loot_Area -|
 /return
@@ -216,9 +227,6 @@ SUB lootCorpse
             /varset importantItem TRUE
         }
          /if (!${importantItem} && ${Corpse.Item[${i}].Name.Equal[The Lady Luck blessings]}) {
-            /varset importantItem TRUE
-        }
-         /if (!${importantItem} && ${Corpse.Item[${i}].Name.Equal[Grobb Frenzy Maxx]}) {
             /varset importantItem TRUE
         }
         /if (${importantItem}) {

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -218,6 +218,9 @@ SUB lootCorpse
          /if (!${importantItem} && ${Corpse.Item[${i}].Name.Equal[The Lady Luck blessings]}) {
             /varset importantItem TRUE
         }
+         /if (!${importantItem} && ${Corpse.Item[${i}].Name.Equal[Grobb Frenzy Maxx]}) {
+            /varset importantItem TRUE
+        }
         /if (${importantItem}) {
 
           /echo [${Time}]: Loot Only Stackable:hard coded important item ${Corpse.Item[${i}].Name}

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -149,10 +149,10 @@ SUB e3_Setup(modeSelect)
 	/if (${Bool[${Ini[${Character_Ini},Heals]}]} && !${Bool[${Ini[${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)]}]}) {
 		/call WriteToIni "${Character_Ini},Heals,Auto Cast Necro Heal Orbs (On/Off)" On
 	}
-
-	
-
-	/echo e3 loaded - Turbo ${classTurbo}
+	/if (${Bool[${Ini[${Character_Ini},Misc]}]} && !${Bool[${Ini[${Character_Ini},Misc,Anchor (Char to Anchor to)]}]}) {
+		/call WriteToIni "${Character_Ini},Misc,Anchor (Char to Anchor to)" ""
+	}
+ 	/echo e3 loaded - Turbo ${classTurbo}
 	
 	/if (${Debug}) {
 		/echo

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -1511,3 +1511,89 @@ SUB Build_Class_Ini(Ini_File)
 SUB event_sendInstanceInvites(line, ChatSender)
 	/dzadd ${ChatSender}
 /return
+
+|----------------------------------------------------------------------------|
+|- Sanity check for when Waiting4Rez may fail								-|
+|----------------------------------------------------------------------------|
+|- Checks inventory and equipment to determine if player might be dead   	-|
+|----------------------------------------------------------------------------|
+sub check_AmIDead_Default
+    
+    /call check_AmIDead 1 1
+
+/return ${Macro.Return}
+
+
+sub check_AmIDead(int equipmentThreshold, int inventoryThreshold)
+/if (${Debug}) /echo [${Time}]: check_AmIDead
+
+    /if (!${Defined[missingEquipment]}) /declare missingEquipment bool local
+    /if (!${Defined[missingInventory]}) /declare missingInventory bool local
+
+    /call check_MissingEquipment ${equipmentThreshold}
+    /varset missingEquipment ${Macro.Return}
+    /call check_MissingInventory ${inventoryThreshold}
+    /varset missingInventory ${Macro.Return}
+    /if (${Debug}) /echo [${Time}]: check_AmIDead: Equipment ${missingEquipment}, Inventory: ${missingInventory}
+    /if (!(${missingEquipment} && ${missingInventory})) {
+        /return false
+    }
+
+/if (${Debug}) /echo [${Time}]: check_AmIDead: Check failed, character may be dead.
+/return true
+|----------------------------------------------------------------------------|
+|-    Equipment 															-|
+|- 1. A mage could summon mod rod in toons proximity, causing the toon to   -|
+|-	  autoinventory it to their mainhand - skip No Rent items 				-|
+|- 2. A player could intentionally have removed an item in any slot for 	-|
+|-	  reasons of their own choosing 										-|
+|- 3. Its common for players to not have offhand (14), powersource (21) or  -|
+|-	  ammo (22)																-|
+|----------------------------------------------------------------------------|
+sub check_MissingEquipment(int threshold)
+/if (${Debug}) /echo [${Time}]: check_MissingEquipment: Start
+
+    /declare i int local 
+    /declare equipmentFound int local
+
+    /for i 0 to 20
+    /if (${i} == 14) /continue
+    /if (${Bool[${InvSlot[${i}].Item.ID}]} && !${Bool[${InvSlot[${i}].Item.NoRent}]}) {
+        /varset equipmentFound ${Math.Calc[${equipmentFound}+1]}
+        /if (${Debug}) /echo [${Time}]: check_MissingEquipment: Item ${InvSlot[${i}].Item.Name} found found in slot: ${InvSlot[${i}]}
+    }
+    
+    /if (${equipmentFound} >= ${threshold}) {
+        /if (${Debug}) /echo [${Time}]: check_MissingEquipment: PASSED
+        /return false
+    } 
+    /next i
+
+/if (${Debug}) /echo [${Time}]: check_MissingEquipment: FAILED
+/return true
+|----------------------------------------------------------------------------|
+|- 	  Inventory 															-|
+|- 1. Going to assume if you have 1 bag or item PASS 						-|
+|- 2. Ignore No Rent items and Folded Packs. These can be summoned onto 	-|
+|- 	  your cursor by other players. 										-|
+|----------------------------------------------------------------------------|
+sub check_MissingInventory(int threshold)
+/if (${Debug}) /echo [${Time}]: check_MissingInventory Start
+
+    /declare i int local
+    /declare inventoryFound int local
+
+    /for i 1 to 10
+    /if (${Bool[${InvSlot[pack${i}].Item.ID}]} && !${Bool[${InvSlot[pack${i}].Item.NoRent}]} && !${Bool[${InvSlot[pack${i}].Item.Name.Find[Folded Pack]}]}) {
+        /varset inventoryFound ${Math.Calc[${inventoryFound}+1]}
+        /if (${Debug}) /echo [${Time}]: check_MissingInventory: Found bag or item ${InvSlot[pack${i}].Item.Name} in slot ${i}
+    }
+
+    /if (${inventoryFound} >= ${threshold}) {
+        /if (${Debug}) /echo [${Time}]: check_MissingInventory: PASSED
+        /return false
+    }
+    /next i
+
+/if (${Debug}) /echo [${Time}]: check_MissingInventory: FAILED
+/return true

--- a/Macros/e3 Includes/e3_Wait4Rez.inc
+++ b/Macros/e3 Includes/e3_Wait4Rez.inc
@@ -31,7 +31,11 @@ SUB EVENT_dead
 		}
 		| Wait for a Rez.
 		/docommand ${ChatToggle} I'm dead. Waiting for rez.
-		/if (!${Defined[Waiting4Rez]}) /declare Waiting4Rez bool outer TRUE
+		/if (!${Defined[Waiting4Rez]}) {
+			/declare Waiting4Rez bool outer TRUE
+		} else {
+			/varset Waiting4Rez TRUE
+		}
 		/call Wait4Rez
 	}
 /if (${Debug} || ${Debug_Wait4Rez}) /echo <== Event_Dead -|
@@ -50,7 +54,11 @@ SUB EVENT_waitNow(line, ChatSender)
 		/consent ${ChatSender}
 		|If I'm not already waiting, wait for a rez.
 		/if (!${Waiting4Rez}) {
-			/if (!${Defined[Waiting4Rez]}) /declare Waiting4Rez bool outer TRUE
+			/if (!${Defined[Waiting4Rez]}) {
+				/declare Waiting4Rez bool outer TRUE
+			} else {
+				/varset Waiting4Rez TRUE
+			}
 			/call Wait4Rez
 		}
 	}


### PR DESCRIPTION
Moved the changes I had submitted on Sirhops repo to here, will leave that PR open for now just in case it helps in reviewing my changes. https://github.com/sirhopsalot/lazarus_mq2_e3/pull/49

Arm Pet command now supports players in or out of group, with a variety of options. I made a wiki page to document most of what it does: https://www.lazaruseq.com/Wiki/index.php/Pet_weapons and https://www.lazaruseq.com/Wiki/index.php/Arm_Pet

- Added support for a Quantity specified in check_Supply. Use the ini format:

Supply=ItemName|SpellName|Delay|SpellGem|Quantity
Supply=Folded Pack of Enibik's Heirlooms|Grant Enibik's Heirlooms|10s|8|12

- Also added additional checks for when the player is dead as it seems Waiting4Rez may not always be true causing the mage to summon Supply items while they are waiting to be rezzed. One checks for the presence of bag in inventory (bag 8) and the other checks that hp is over 10K (because most players wearing gear will be more than that at 70). If these aren't good let me know what other things can be checked instead.
- Added logic in event_armPets to better handle the bag slot requirements:
- It will check for existing folded packs and move them to a bag
- Looks for unfolded packs and destroys them (it also checks the packs only contain summoned items before destroying)
- When finished, it will return the item found to the main bag slot, to prevent an item being auto inventoried to the bag slot
- When handing weapons to pets, the mage will use folded packs in their inventory before summoning new ones - this allows them to arm multiple pets faster
